### PR TITLE
Fix timecode copy

### DIFF
--- a/cinepi/cinepi_controller.cpp
+++ b/cinepi/cinepi_controller.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <iomanip>
 #include <sstream>
+#include <cstring>
 
 using namespace std;
 using namespace std::chrono;
@@ -229,7 +230,9 @@ void CinePIController::process(CompletedRequestPtr &completed_request){
      *  Keep current timecode in Redis (TC_CAM0/TC_CAM1)
      * ------------------------------------------------------ */
     /* use the last time-code produced by the encoder */
-    auto &tc_bcd = app_->GetEncoder()->originationTimeCode;
+    uint64_t tc64 = app_->GetEncoder()->getOriginationTimeCode();
+    uint8_t tc_bcd[8];
+    std::memcpy(tc_bcd, &tc64, sizeof(tc_bcd));
 
     int hour  = ((tc_bcd[3] >> 4) & 0xF) * 10 + (tc_bcd[3] & 0xF);
     int minute= ((tc_bcd[2] >> 4) & 0xF) * 10 + (tc_bcd[2] & 0xF);

--- a/cinepi/cinepi_sound.cpp
+++ b/cinepi/cinepi_sound.cpp
@@ -4,6 +4,7 @@
 #include <boost/rational.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 #include <fstream>
+#include <cstring>
 
 constexpr int FIXED_AUDIO_SAMPLE_RATE = 48000;
 
@@ -361,7 +362,9 @@ void CinePISound::soundThread() {
                 std::ostringstream bwfedit;
                 bwfedit << "bwfmetaedit " << filename << " --in-iXML=" << xml_oss.str();
                 std::ostringstream bwfedit_core;
-                auto& oTC = app_->GetEncoder()->originationTimeCode;
+                uint64_t tc64 = app_->GetEncoder()->getOriginationTimeCode();
+                uint8_t oTC[8];
+                std::memcpy(oTC, &tc64, sizeof(oTC));
                 auto& oDt = app_->GetEncoder()->originationDate;
 
                 uint64_t timeReference = (static_cast<uint64_t>(oTC[0]) * 3600 * audioSampleRate)

--- a/cinepi/dng_encoder.cpp
+++ b/cinepi/dng_encoder.cpp
@@ -681,7 +681,10 @@ size_t DngEncoder::dng_save([[maybe_unused]] int               /*thread_num*/,
     };
 
     /* store time-code & date for other modules */
-    std::copy(std::begin(tc), std::end(tc), origination .begin());
+    std::copy(std::begin(tc), std::end(tc), originationTimeCode.begin());
+    uint64_t tc64 = 0;
+    std::memcpy(&tc64, tc, sizeof(tc64));
+    originationTimeCodeAtomic_.store(tc64, std::memory_order_relaxed);
     originationDate[0] = static_cast<uint16_t>(lt->tm_year + 1900);
     originationDate[1] = static_cast<uint16_t>(lt->tm_mon + 1);
     originationDate[2] = static_cast<uint16_t>(lt->tm_mday);

--- a/cinepi/dng_encoder.hpp
+++ b/cinepi/dng_encoder.hpp
@@ -76,8 +76,13 @@ public:
 	bool mono_ = false;
 
 	std::vector<int64_t> timestamps;
-	std::array<uint8_t, 8> originationTimeCode;
-	std::array<uint16_t, 3> originationDate;
+        std::array<uint8_t, 8> originationTimeCode;
+        std::atomic<uint64_t>  originationTimeCodeAtomic_{0};
+        std::array<uint16_t, 3> originationDate;
+
+        uint64_t getOriginationTimeCode() const {
+            return originationTimeCodeAtomic_.load(std::memory_order_relaxed);
+        }
 
 	/* ---- PUBLIC: number of frame buffers that fit in RAM ---- */
 	size_t maxRamBuffers() const { return max_ram_buffers_; }


### PR DESCRIPTION
## Summary
- make timecode thread-safe so encoder and controller share per-frame values

------
https://chatgpt.com/codex/tasks/task_e_687c36f1f3988332ac41c276790b84b8