### PR TITLE
Add Redis timestamp publishing

### DIFF
--- a/cinepi/cinepi_controller.cpp
+++ b/cinepi/cinepi_controller.cpp
@@ -223,7 +223,11 @@ void CinePIController::process(CompletedRequestPtr &completed_request){
     data["focus"] = info.focus;
     data["frameCount"] = app_->GetEncoder()->getFrameCount();
     data["bufferSize"] = app_->GetEncoder()->bufferSize();
+    data["timestamp"] = (Json::Int64)info.ts;
     redis_->publish(CHANNEL_STATS, data.toStyledString());
+
+    std::string ts_key = (options_->CamPort() == "cam1") ? "timestamp_cam1" : "timestamp_cam0";
+    redis_->set(ts_key, std::to_string(info.ts));
 
     /* --------------------------------------------------------
      *  Keep current timecode in Redis (TC_CAM0/TC_CAM1)


### PR DESCRIPTION
## Summary
- store each frame's timestamp in stats message
- write timestamp_camX key depending on cam-port

## Testing
- `apt-get update` *(fails: repository not signed due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687c6406f7bc8332be97a2655c360f10