### PR TITLE
Disable fps redis updates in sync client mode

### DIFF
--- a/cinepi/cinepi_controller.cpp
+++ b/cinepi/cinepi_controller.cpp
@@ -58,11 +58,18 @@ void CinePIController::sync(){
     console->critical(2);
 
     auto framerate = pipe_replies.get<OptionalString>(2);
-    if(framerate){
+    if (options_->sync == 2)                      // sync client → ignore Redis
+    {
+        framerate_ = options_->framerate.value_or(CP_DEF_FRAMERATE);
+    }
+    else if (framerate)
+    {
         framerate_ = stoi(*framerate);
-    }else{
+    }
+    else
+    {
         framerate_ = CP_DEF_FRAMERATE;
-        redis_->set(CONTROL_KEY_FRAMERATE, to_string(framerate_)); 
+        redis_->set(CONTROL_KEY_FRAMERATE, to_string(framerate_));
     }
 
     console->critical(3);
@@ -452,9 +459,11 @@ void CinePIController::mainThread(){
             }
         }},
         { CONTROL_KEY_FRAMERATE, [this](const std::optional<std::string>& r) {
-            if(r) {
-                framerate_ = stof(*r);
-                options_->framerate = framerate_;
+            if (!r || options_->sync == 2)
+                return;                 // ignore when sync client
+
+            framerate_ = stof(*r);
+            options_->framerate = framerate_;
 
                 long int durationValues[2] = { static_cast<long int>(1000000.0 / framerate_),
                                             static_cast<long int>(1000000.0 / framerate_) };


### PR DESCRIPTION
## Summary
- avoid reading Redis `fps` value when sync mode is `client`
- ignore `fps` pub/sub messages in client sync mode

## Testing
- `apt-get update` *(fails: internet disabled)*
- `meson setup build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68877f57242c8332a3ed07c5b0731eed