### PR TITLE
Sync-FPS defaults framerate

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ The following flags extend the base `rpicam-apps` functionality with CinePi-rawâ
 | `--hdmi-port <int>`     | `-1`              | Choose a specific HDMI connector for the DRM preview:<br>`0` = HDMI-0, `1` = HDMI-1, `-1` = automatic. |
 | `--same-hdmi`           | `false`           | Force both CinePi apps (capture & controller) to share the same HDMI output.                        |
 | `--keep16`              | `false`           | Write full 16-bit DNG files; **disable** 12-bit packing of 16-bit streams.                            |
-| `--sync-fps <float>`    | `30.0`            | Frame rate for generated sync pulses. If `--framerate` is omitted, this value becomes the camera framerate when sync is enabled. |
+| `--sync-fps <float>`    | `30.0`            | Frame rate for generated sync pulses. When using `--sync client` and `--framerate` is omitted, this value becomes the camera framerate. |
 
-When synchronization is active, omitting `--framerate` means the value of `--sync-fps` will be used as the camera's framerate.
+When `--sync client` is active, omitting `--framerate` means the value of `--sync-fps` will be used as the camera's framerate. Without the client flag, the framerate is controlled via Redis.
 
 ## Manual DNG encoder
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,9 @@ The following flags extend the base `rpicam-apps` functionality with CinePi-rawâ
 | `--hdmi-port <int>`     | `-1`              | Choose a specific HDMI connector for the DRM preview:<br>`0` = HDMI-0, `1` = HDMI-1, `-1` = automatic. |
 | `--same-hdmi`           | `false`           | Force both CinePi apps (capture & controller) to share the same HDMI output.                        |
 | `--keep16`              | `false`           | Write full 16-bit DNG files; **disable** 12-bit packing of 16-bit streams.                            |
+| `--sync-fps <float>`    | `30.0`            | Frame rate for generated sync pulses. If `--framerate` is omitted, this value becomes the camera framerate when sync is enabled. |
 
+When synchronization is active, omitting `--framerate` means the value of `--sync-fps` will be used as the camera's framerate.
 
 ## Manual DNG encoder
 

--- a/cinepi/cinepi_controller.cpp
+++ b/cinepi/cinepi_controller.cpp
@@ -60,7 +60,7 @@ void CinePIController::sync(){
     auto framerate = pipe_replies.get<OptionalString>(2);
     if (options_->sync == 2)                      // sync client → ignore Redis
     {
-        framerate_ = options_->framerate.value_or(CP_DEF_FRAMERATE);
+        framerate_ = options_->framerate.value_or(options_->SyncFps());
     }
     else if (framerate)
     {
@@ -68,7 +68,9 @@ void CinePIController::sync(){
     }
     else
     {
-        framerate_ = CP_DEF_FRAMERATE;
+        framerate_ = (options_->sync != 0 && !options_->framerate)
+                          ? options_->SyncFps()
+                          : options_->framerate.value_or(CP_DEF_FRAMERATE);
         redis_->set(CONTROL_KEY_FRAMERATE, to_string(framerate_));
     }
 

--- a/cinepi/cinepi_controller.cpp
+++ b/cinepi/cinepi_controller.cpp
@@ -68,9 +68,7 @@ void CinePIController::sync(){
     }
     else
     {
-        framerate_ = (options_->sync != 0 && !options_->framerate)
-                          ? options_->SyncFps()
-                          : options_->framerate.value_or(CP_DEF_FRAMERATE);
+        framerate_ = CP_DEF_FRAMERATE;
         redis_->set(CONTROL_KEY_FRAMERATE, to_string(framerate_));
     }
 

--- a/cinepi/cinepi_options.cpp
+++ b/cinepi/cinepi_options.cpp
@@ -277,7 +277,7 @@ bool CinePiOptions::Parse(int argc, char *argv[])
             sync_chip,
             sync_line);
 
-        if (sync != 0 && !framerate)
+        if (sync == 2 && !framerate)
             spdlog::info("--framerate not specified; using --sync-fps ({}) as camera framerate", sync_fps);
 
         return ok;

--- a/cinepi/cinepi_options.cpp
+++ b/cinepi/cinepi_options.cpp
@@ -277,5 +277,8 @@ bool CinePiOptions::Parse(int argc, char *argv[])
             sync_chip,
             sync_line);
 
+        if (sync != 0 && !framerate)
+            spdlog::info("--framerate not specified; using --sync-fps ({}) as camera framerate", sync_fps);
+
         return ok;
 }


### PR DESCRIPTION
## Summary
- use `--sync-fps` value when no explicit framerate is given while sync is active
- log when `--sync-fps` implicitly sets framerate
- document `--sync-fps` behaviour in README

## Testing
- `python3 -m py_compile utils/test.py`
- `meson test` *(fails: meson not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887a7a5e4208332970c1518a770e705