### PR TITLE
Sync-FPS defaults framerate

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,9 @@ The following flags extend the base `rpicam-apps` functionality with CinePi-rawâ
 | `--hdmi-port <int>`     | `-1`              | Choose a specific HDMI connector for the DRM preview:<br>`0` = HDMI-0, `1` = HDMI-1, `-1` = automatic. |
 | `--same-hdmi`           | `false`           | Force both CinePi apps (capture & controller) to share the same HDMI output.                        |
 | `--keep16`              | `false`           | Write full 16-bit DNG files; **disable** 12-bit packing of 16-bit streams.                            |
+| `--sync-fps <float>`    | `30.0`            | Frame rate for generated sync pulses. When using `--sync client` and `--framerate` is omitted, this value becomes the camera framerate. |
 
+When `--sync client` is active, omitting `--framerate` means the value of `--sync-fps` will be used as the camera's framerate. Without the client flag, the framerate is controlled via Redis.
 
 ## Manual DNG encoder
 

--- a/cinepi/cinepi_controller.cpp
+++ b/cinepi/cinepi_controller.cpp
@@ -60,7 +60,7 @@ void CinePIController::sync(){
     auto framerate = pipe_replies.get<OptionalString>(2);
     if (options_->sync == 2)                      // sync client → ignore Redis
     {
-        framerate_ = options_->framerate.value_or(CP_DEF_FRAMERATE);
+        framerate_ = options_->framerate.value_or(options_->SyncFps());
     }
     else if (framerate)
     {

--- a/cinepi/cinepi_hw_sync.cpp
+++ b/cinepi/cinepi_hw_sync.cpp
@@ -18,6 +18,9 @@
 #include <errno.h>
 #include <spdlog/spdlog.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <poll.h>
 #ifdef HAVE_LGPIO
 #include <lgpio.h>
 #include <atomic>
@@ -155,9 +158,33 @@ int main(int argc, char **argv)
         console->info("GPIO alert callback installed");
     }
 #else
+    int gpio_fd = -1;
+    bool gpio_exported = false;
     if (source == "gpio") {
-        console->error("GPIO source requested but lgpio not available");
-        return 1;
+        std::string base = "/sys/class/gpio/gpio" + std::to_string(line);
+        struct stat st;
+        if (stat(base.c_str(), &st) < 0) {
+            int fd = open("/sys/class/gpio/export", O_WRONLY);
+            if (fd >= 0) {
+                std::string s = std::to_string(line);
+                write(fd, s.c_str(), s.size());
+                close(fd);
+                gpio_exported = true;
+            }
+        }
+        std::string dir = base + "/direction";
+        int fd = open(dir.c_str(), O_WRONLY);
+        if (fd >= 0) { write(fd, "in", 2); close(fd); }
+        std::string edge = base + "/edge";
+        fd = open(edge.c_str(), O_WRONLY);
+        if (fd >= 0) { write(fd, "rising", 6); close(fd); }
+        std::string val = base + "/value";
+        gpio_fd = open(val.c_str(), O_RDONLY | O_NONBLOCK);
+        if (gpio_fd < 0) {
+            console->error("Failed to open GPIO value file {}", val);
+            return 1;
+        }
+        console->info("GPIO sysfs monitoring line {}", line);
     }
 #endif
 
@@ -180,11 +207,22 @@ int main(int argc, char **argv)
             nowUs = gpioctx.ts.load() / 1000; // lgpio timestamp is in ns
             gpioctx.ready = false;
         }
+#else
+        else if (source == "gpio") {
+            struct pollfd pfd{ gpio_fd, POLLPRI, 0 };
+            poll(&pfd, 1, -1);
+            lseek(gpio_fd, 0, SEEK_SET);
+            char buf[8];
+            read(gpio_fd, buf, sizeof(buf));
+            nowUs = duration_cast<microseconds>(system_clock::now().time_since_epoch()).count();
+        }
 #endif
         else {
             console->error("Unknown source type: {}", source);
             return 1;
         }
+
+        console->info("Pulse {} received at {} us", frame, nowUs);
 
         if (!first) {
             uint64_t diff = nowUs - prevUs;
@@ -214,6 +252,17 @@ int main(int argc, char **argv)
     if (chip >= 0) {
         lgGpiochipClose(chip);
         console->info("GPIO chip closed");
+    }
+#else
+    if (gpio_fd >= 0)
+        close(gpio_fd);
+    if (gpio_exported) {
+        int fd = open("/sys/class/gpio/unexport", O_WRONLY);
+        if (fd >= 0) {
+            std::string s = std::to_string(line);
+            write(fd, s.c_str(), s.size());
+            close(fd);
+        }
     }
 #endif
 

--- a/cinepi/cinepi_options.cpp
+++ b/cinepi/cinepi_options.cpp
@@ -277,5 +277,8 @@ bool CinePiOptions::Parse(int argc, char *argv[])
             sync_chip,
             sync_line);
 
+        if (sync == 2 && !framerate)
+            spdlog::info("--framerate not specified; using --sync-fps ({}) as camera framerate", sync_fps);
+
         return ok;
 }


### PR DESCRIPTION
## Summary
- default to `CP_DEF_FRAMERATE` unless `--sync client` is used
- adjust log about `--sync-fps` behaviour
- clarify README description for `--sync-fps`
- allow `cinepi-hw-sync` to monitor GPIO lines without lgpio using sysfs
- log each incoming pulse in `cinepi-hw-sync`

## Testing
- `python3 -m py_compile utils/test.py`
- `meson test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887a7a5e4208332970c1518a770e705