### PR TITLE
Enable configurable PWM fps

### DIFF
--- a/cinepi/cinepi_hw_sync.cpp
+++ b/cinepi/cinepi_hw_sync.cpp
@@ -73,17 +73,20 @@ static void usage(const char *argv0)
     cout << "Usage: " << argv0
          << " [--source timer|stdin|gpio] [--fps N]\n"
          << "            [--group ADDRESS] [--port PORT]\n"
-         << "            [--chip NAME] [--line PIN]\n";
+         << "            [--chip NAME] [--line PIN]\n"
+         << "            [--out-pin PIN] [--out-fps N]";
 }
 
 int main(int argc, char **argv)
 {
     string source = "timer";
     double fps = 30.0;
+    double outFps = 30.0;
     string group = "239.255.255.250";
     uint16_t port = 10000;
     string chipName = "gpiochip4";
     int line = -1;
+    int outLine = -1;
 
     for (int i = 1; i < argc; ++i) {
         string arg = argv[i];
@@ -91,6 +94,7 @@ int main(int argc, char **argv)
             source = argv[++i];
         } else if (arg == "--fps" && i + 1 < argc) {
             fps = stod(argv[++i]);
+            outFps = fps;
         } else if (arg == "--group" && i + 1 < argc) {
             group = argv[++i];
         } else if (arg == "--port" && i + 1 < argc) {
@@ -99,6 +103,10 @@ int main(int argc, char **argv)
             chipName = argv[++i];
         } else if (arg == "--line" && i + 1 < argc) {
             line = stoi(argv[++i]);
+        } else if (arg == "--out-pin" && i + 1 < argc) {
+            outLine = stoi(argv[++i]);
+        } else if (arg == "--out-fps" && i + 1 < argc) {
+            outFps = stod(argv[++i]);
         } else {
             usage(argv[0]);
             return 0;
@@ -117,10 +125,15 @@ int main(int argc, char **argv)
     addr.sin_port = htons(port);
 
     microseconds frameDuration(static_cast<int>(1e6 / fps));
+    microseconds outFrameDuration(static_cast<int>(1e6 / outFps));
+    if (outFps != fps)
+        console->info("Output pulse fps {} (main fps {})", outFps, fps);
     uint64_t frame = 0;
     console->info("libcamera-hw-sync started with source={} fps={}", source, fps);
     if (source == "gpio")
         console->info("GPIO chip={} line={}", chipName, line);
+    if (outLine >= 0)
+        console->info("Output pin {} enabled at {} fps", outLine, outFps);
 
 #ifdef HAVE_LGPIO
     int chip = -1;
@@ -129,7 +142,7 @@ int main(int argc, char **argv)
 #endif
 
 #ifdef HAVE_LGPIO
-    if (source == "gpio") {
+    if (source == "gpio" || outLine >= 0) {
         int num = 0;
         if (chipName.rfind("gpiochip", 0) == 0)
             num = stoi(chipName.substr(8));
@@ -145,25 +158,39 @@ int main(int argc, char **argv)
         }
         console->info("GPIO chip {} opened", chipName);
 
-        rc = lgGpioClaimAlert(chip, 0, LG_RISING_EDGE, line, -1);
-        if (rc < 0) {
-            console->error("Failed to claim alert on line {}", line);
-            return 1;
-        }
-        console->info("Alert claimed on GPIO line {}", line);
+        if (source == "gpio") {
+            rc = lgGpioClaimAlert(chip, 0, LG_RISING_EDGE, line, -1);
+            if (rc < 0) {
+                console->error("Failed to claim alert on line {}", line);
+                return 1;
+            }
+            console->info("Alert claimed on GPIO line {}", line);
 
-        rc = lgGpioSetAlertsFunc(chip, line, gpio_alert_cb, &gpioctx);
-        if (rc < 0) {
-            console->error("Failed to set alert callback");
-            return 1;
+            rc = lgGpioSetAlertsFunc(chip, line, gpio_alert_cb, &gpioctx);
+            if (rc < 0) {
+                console->error("Failed to set alert callback");
+                return 1;
+            }
+            console->info("GPIO alert callback installed");
         }
-        console->info("GPIO alert callback installed");
+
+        if (outLine >= 0) {
+            rc = lgGpioClaimOutput(chip, 0, outLine, 0);
+            if (rc < 0) {
+                console->error("Failed to claim output on line {}", outLine);
+                return 1;
+            }
+            console->info("Output GPIO line {} claimed", outLine);
+        }
     }
 #else  /* ---------- sysfs fallback when HAVE_LGPIO is not defined ---------- */
     int  gpio_fd       = -1;
     bool gpio_exported = false;
+    int  out_fd        = -1;
+    bool out_exported  = false;
+    int  out_global_line = -1;
 
-    if (source == "gpio") {
+    if (source == "gpio" || outLine >= 0) {
         /* Translate (chipName,line)  → global GPIO number used by sysfs */
         int global_line = line;
         if (chipName.rfind("gpiochip", 0) == 0) {
@@ -182,6 +209,18 @@ int main(int argc, char **argv)
         }
 
         std::string base = "/sys/class/gpio/gpio" + std::to_string(global_line);
+        int out_global = outLine;
+        if (outLine >= 0 && chipName.rfind("gpiochip", 0) == 0) {
+            int chip_idx = std::stoi(chipName.substr(8));
+            std::string base_file_out =
+                "/sys/class/gpio/gpiochip" + std::to_string(chip_idx) + "/base";
+            FILE *f = fopen(base_file_out.c_str(), "r");
+            if (f) { int b = 0; fscanf(f, "%d", &b); fclose(f); out_global = b + outLine; }
+        }
+        out_global_line = out_global;
+        std::string base_out;
+        if (outLine >= 0)
+            base_out = "/sys/class/gpio/gpio" + std::to_string(out_global);
 
         /* ------------------------------------------------------------------
          * 1. export the line (needs root or udev rule that gives you write
@@ -202,6 +241,16 @@ int main(int argc, char **argv)
             gpio_exported = true;
         }
 
+        if (outLine >= 0 && stat(base_out.c_str(), &st) < 0) {
+            int fd = open("/sys/class/gpio/export", O_WRONLY);
+            if (fd >= 0) {
+                std::string s = std::to_string(out_global);
+                write(fd, s.c_str(), s.size());
+                close(fd);
+                out_exported = true;
+            }
+        }
+
         /* wait until the kernel has created the directory */
         for (int i = 0; i < 100; ++i) {        // up to ~1 s total
             if (stat(base.c_str(), &st) == 0)
@@ -210,6 +259,10 @@ int main(int argc, char **argv)
         }
         if (stat(base.c_str(), &st) < 0) {
             console->error("GPIO {} did not appear under /sys/class/gpio", global_line);
+            return 1;
+        }
+        if (outLine >= 0 && stat(base_out.c_str(), &st) < 0) {
+            console->error("GPIO {} did not appear under /sys/class/gpio", out_global);
             return 1;
         }
 
@@ -221,6 +274,10 @@ int main(int argc, char **argv)
 
         write_str(base + "/direction", "in");
         write_str(base + "/edge",      "rising");
+        if (outLine >= 0) {
+            write_str(base_out + "/direction", "out");
+            write_str(base_out + "/value", "0");
+        }
 
         /* open the value file non-blocking so we can poll() on it */
         std::string val = base + "/value";
@@ -229,12 +286,18 @@ int main(int argc, char **argv)
             console->error("Failed to open GPIO value file {} ({})", val, strerror(errno));
             return 1;
         }
+        if (outLine >= 0) {
+            out_fd = open((base_out + "/value").c_str(), O_WRONLY);
+            if (out_fd < 0)
+                console->warn("Failed to open output GPIO value file {}", base_out + "/value");
+        }
         console->info("GPIO sysfs monitoring global line {}", global_line);
     }
 #endif /* --------- end of sysfs fallback block --------- */
 
     uint64_t prevUs = 0;
     bool first = true;
+    uint64_t lastOutUs = 0;
 
     while (true) {
         uint64_t nowUs;
@@ -280,6 +343,25 @@ int main(int argc, char **argv)
         first = false;
         prevUs = nowUs;
 
+        if (outLine >= 0 && (lastOutUs == 0 || nowUs - lastOutUs >= outFrameDuration.count())) {
+#ifdef HAVE_LGPIO
+            lgGpioWrite(chip, outLine, 1);
+            this_thread::sleep_for(std::chrono::milliseconds(5));
+            lgGpioWrite(chip, outLine, 0);
+#else
+            if (out_fd >= 0) {
+                write(out_fd, "1", 1);
+                fsync(out_fd);
+                this_thread::sleep_for(std::chrono::milliseconds(5));
+                lseek(out_fd, 0, SEEK_SET);
+                write(out_fd, "0", 1);
+                fsync(out_fd);
+                lseek(out_fd, 0, SEEK_SET);
+            }
+#endif
+            lastOutUs = nowUs;
+        }
+
         SyncPayload payload{};
         payload.frameDuration = frameDuration.count();
         payload.wallClockFrameTimestamp = nowUs;
@@ -301,11 +383,19 @@ int main(int argc, char **argv)
 #else
     if (gpio_fd >= 0)
         close(gpio_fd);
-    if (gpio_exported) {
+    if (out_fd >= 0)
+        close(out_fd);
+    if (gpio_exported || out_exported) {
         int fd = open("/sys/class/gpio/unexport", O_WRONLY);
         if (fd >= 0) {
-            std::string s = std::to_string(line);
-            write(fd, s.c_str(), s.size());
+            if (gpio_exported) {
+                std::string s = std::to_string(line);
+                write(fd, s.c_str(), s.size());
+            }
+            if (out_exported) {
+                std::string s2 = std::to_string(out_global_line);
+                write(fd, s2.c_str(), s2.size());
+            }
             close(fd);
         }
     }


### PR DESCRIPTION
## Summary
- allow specifying `--out-fps` for pwm output
- print enabled pin and fps
- gate output pulses based on the desired rate

## Testing
- `g++ -std=c++17 -Wall -c cinepi/cinepi_hw_sync.cpp -o /tmp/cinepi_hw_sync.o` *(fails: spdlog/spdlog.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6887d1a07af0833294c6ddd88835d431