### PR TITLE
Add CLI worker tuning and thread affinity for the DNG encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,13 +111,18 @@ _Adapted to libcamera 0.5 / rpicam-apps 1.0.7._
 
 The following flags extend the base `rpicam-apps` functionality with CinePi-raw–specific features:
 
-| Flag                    | Default           | Description                                                                                          |
-|-------------------------|-------------------|------------------------------------------------------------------------------------------------------|
-| `--cam-port <string>`   | `""`              | Physical camera port to use (e.g. `cam0` or `cam1`).                                         |
-| `--hdmi-port <int>`     | `-1`              | Choose a specific HDMI connector for the DRM preview:<br>`0` = HDMI-0, `1` = HDMI-1, `-1` = automatic. |
-| `--same-hdmi`           | `false`           | Force both CinePi apps (capture & controller) to share the same HDMI output.                        |
-| `--keep16`              | `false`           | Write full 16-bit DNG files; **disable** 12-bit packing of 16-bit streams.                            |
-
+| Flag                      | Default | Description |
+|---------------------------|---------|-------------|
+| `--cam-port <string>`     | `""`    | Physical camera port to use (e.g. `cam0` or `cam1`). |
+| `--hdmi-port <int>`       | `-1`    | Choose a specific HDMI connector for the DRM preview:<br>`0` = HDMI-0, `1` = HDMI-1, `-1` = automatic. |
+| `--same-hdmi`             | `false` | Force both CinePi apps (capture & controller) to share the same HDMI output. |
+| `--keep16`                | `false` | Write full 16-bit DNG files; **disable** 12-bit packing of 16-bit streams. |
+| `--encode-workers <n>`    | `2`     | Number of DNG encode worker threads to spawn (min. `1`). |
+| `--disk-workers <n>`      | `8`     | Number of disk writer threads used for flushing DNGs (min. `1`). |
+| `--encode-affinity <list>`| `auto`  | Pin encode workers to a CPU list (e.g. `4,5` or `2-5`). |
+| `--disk-affinity <list>`  | `auto`  | Pin disk workers to the specified CPU list. |
+| `--encode-nice <int>`     | `auto`  | Nice level for encode workers (`-20` = highest priority, `19` = lowest). |
+| `--disk-nice <int>`       | `auto`  | Nice level applied to disk workers. |
 
 ## Manual DNG encoder
 
@@ -128,6 +133,23 @@ The following flags extend the base `rpicam-apps` functionality with CinePi-raw�
 - Packs the 16 bit files to 12 bit, unless `--keep16` is used.
 
 - Supports both IMX 585 color and mono variants.
+
+### Worker pool tuning examples
+
+- **Cooler operation:** Limit the encoder and disk workers if you want to reduce thermal load. For example:
+
+  ```bash
+  cinepi-raw --encode-workers 4 --disk-workers 4 [other options]
+  ```
+
+- **Steer workloads to specific CPUs:** Combine affinity and nice controls to keep background threads off the CPU cores you care about:
+
+  ```bash
+  cinepi-raw --encode-workers 4 --encode-affinity 4-5 --encode-nice -5 \
+             --disk-workers 2 --disk-affinity 0-3 --disk-nice 8 [other options]
+  ```
+
+  This example pins encode workers to CPUs 4–5 with a higher priority while leaving disk flush threads on the little cores with a lower scheduling priority.
   
 ## Audio recording
 

--- a/cinepi/cinepi_options.cpp
+++ b/cinepi/cinepi_options.cpp
@@ -4,7 +4,10 @@
 
 #include <boost/program_options.hpp>
 #include <spdlog/spdlog.h>
+#include <algorithm>
 #include <cstdlib>
+#include <limits>
+#include <optional>
 #include <stdexcept>
 #include <sstream>
 
@@ -48,7 +51,25 @@ CinePiOptions::CinePiOptions()
                 ("scaler-crops",
                     value<std::string>()->implicit_value(""),
                     "Per-stream crop rectangles as fractions:\n"
-                    "x,y,w,h[:x,y,w,h ...]   (0-1, up to 3 streams)");
+                    "x,y,w,h[:x,y,w,h ...]   (0-1, up to 3 streams)")
+                ("encode-workers",
+                    value<unsigned int>()->default_value(2),
+                    "Number of DNG encode worker threads")
+                ("disk-workers",
+                    value<unsigned int>()->default_value(8),
+                    "Number of DNG disk writer threads")
+                ("encode-affinity",
+                    value<std::string>()->implicit_value(""),
+                    "CPU list (e.g. 4,5 or 2-3) to pin encode workers")
+                ("disk-affinity",
+                    value<std::string>()->implicit_value(""),
+                    "CPU list (e.g. 0-1) to pin disk workers")
+                ("encode-nice",
+                    value<int>(),
+                    "Nice level (-20..19) for encode workers")
+                ("disk-nice",
+                    value<int>(),
+                    "Nice level (-20..19) for disk workers");
         options_.add(cinepi_group);
 }
 
@@ -62,6 +83,129 @@ static std::array<float,4> parseCrop(const std::string &tok)
     if (sscanf(tok.c_str(), "%f,%f,%f,%f", &x,&y,&w,&h) != 4)
         throw std::runtime_error("Invalid --scaler-crops token: " + tok);
     return { x,y,w,h };
+}
+
+
+static std::string trimToken(const std::string &token)
+{
+        const auto start = token.find_first_not_of(" \t");
+        if (start == std::string::npos)
+                return "";
+        const auto end = token.find_last_not_of(" \t");
+        return token.substr(start, end - start + 1);
+}
+
+static unsigned int parseWorkerCount(const std::string &flag, const std::string &value)
+{
+        try
+        {
+                size_t pos = 0;
+                unsigned long parsed = std::stoul(value, &pos, 10);
+                if (pos != value.size())
+                        throw std::runtime_error(flag + " contains trailing characters: " + value.substr(pos));
+                if (parsed == 0)
+                        throw std::runtime_error(flag + " must be greater than zero");
+                if (parsed > std::numeric_limits<uint32_t>::max())
+                        throw std::runtime_error(flag + " exceeds supported range");
+                return static_cast<unsigned int>(parsed);
+        }
+        catch (const std::invalid_argument &)
+        {
+                throw std::runtime_error(flag + " requires a positive integer value");
+        }
+        catch (const std::out_of_range &)
+        {
+                throw std::runtime_error(flag + " is out of range");
+        }
+}
+
+static int parseNiceValue(const std::string &flag, const std::string &value)
+{
+        try
+        {
+                size_t pos = 0;
+                int parsed = std::stoi(value, &pos, 10);
+                if (pos != value.size())
+                        throw std::runtime_error(flag + " contains trailing characters: " + value.substr(pos));
+                if (parsed < -20 || parsed > 19)
+                        throw std::runtime_error(flag + " must be between -20 and 19");
+                return parsed;
+        }
+        catch (const std::invalid_argument &)
+        {
+                throw std::runtime_error(flag + " requires an integer value");
+        }
+        catch (const std::out_of_range &)
+        {
+                throw std::runtime_error(flag + " is out of range");
+        }
+}
+
+static std::vector<int> parseCpuList(const std::string &flag, const std::string &value)
+{
+        if (value.empty())
+                throw std::runtime_error(flag + " requires a CPU list");
+
+        std::vector<int> cpus;
+        std::stringstream ss(value);
+        std::string token;
+
+        while (std::getline(ss, token, ','))
+        {
+                token = trimToken(token);
+                if (token.empty())
+                        throw std::runtime_error(flag + " contains an empty entry");
+
+                auto dash = token.find('-');
+                if (dash == std::string::npos)
+                {
+                        size_t pos = 0;
+                        int cpu = std::stoi(token, &pos, 10);
+                        if (pos != token.size() || cpu < 0)
+                                throw std::runtime_error(flag + " has invalid CPU index: " + token);
+                        cpus.push_back(cpu);
+                        continue;
+                }
+
+                std::string start_str = trimToken(token.substr(0, dash));
+                std::string end_str   = trimToken(token.substr(dash + 1));
+                if (start_str.empty() || end_str.empty())
+                        throw std::runtime_error(flag + " has invalid range: " + token);
+
+                size_t pos1 = 0;
+                size_t pos2 = 0;
+                int start_cpu = std::stoi(start_str, &pos1, 10);
+                int end_cpu   = std::stoi(end_str, &pos2, 10);
+                if (pos1 != start_str.size() || pos2 != end_str.size() || start_cpu < 0 || end_cpu < 0)
+                        throw std::runtime_error(flag + " has invalid range: " + token);
+                if (end_cpu < start_cpu)
+                        throw std::runtime_error(flag + " has descending range: " + token);
+
+                for (int cpu = start_cpu; cpu <= end_cpu; ++cpu)
+                        cpus.push_back(cpu);
+        }
+
+        if (cpus.empty())
+                throw std::runtime_error(flag + " resolved to an empty CPU set");
+
+        std::sort(cpus.begin(), cpus.end());
+        cpus.erase(std::unique(cpus.begin(), cpus.end()), cpus.end());
+        return cpus;
+}
+
+static std::string cpuListToString(const std::optional<std::vector<int>> &cpus)
+{
+        if (!cpus || cpus->empty())
+                return std::string("auto");
+
+        std::ostringstream oss;
+        for (size_t i = 0; i < cpus->size(); ++i)
+        {
+                if (i)
+                        oss << ',';
+                oss << (*cpus)[i];
+        }
+        return oss.str();
 }
 
 
@@ -132,6 +276,72 @@ bool CinePiOptions::Parse(int argc, char *argv[])
                         continue;
                 }
 
+                if (arg.rfind("--encode-workers=", 0) == 0) {
+                        RawOptions::encode_workers = parseWorkerCount("--encode-workers", arg.substr(sizeof("--encode-workers=") - 1));
+                        continue;
+                }
+                if (arg == "--encode-workers") {
+                        if (i + 1 >= argc)
+                                throw std::runtime_error("--encode-workers requires a value");
+                        RawOptions::encode_workers = parseWorkerCount("--encode-workers", argv[++i]);
+                        continue;
+                }
+
+                if (arg.rfind("--disk-workers=", 0) == 0) {
+                        RawOptions::disk_workers = parseWorkerCount("--disk-workers", arg.substr(sizeof("--disk-workers=") - 1));
+                        continue;
+                }
+                if (arg == "--disk-workers") {
+                        if (i + 1 >= argc)
+                                throw std::runtime_error("--disk-workers requires a value");
+                        RawOptions::disk_workers = parseWorkerCount("--disk-workers", argv[++i]);
+                        continue;
+                }
+
+                if (arg.rfind("--encode-affinity=", 0) == 0) {
+                        RawOptions::encode_affinity = parseCpuList("--encode-affinity", arg.substr(sizeof("--encode-affinity=") - 1));
+                        continue;
+                }
+                if (arg == "--encode-affinity") {
+                        if (i + 1 >= argc)
+                                throw std::runtime_error("--encode-affinity requires a value");
+                        RawOptions::encode_affinity = parseCpuList("--encode-affinity", argv[++i]);
+                        continue;
+                }
+
+                if (arg.rfind("--disk-affinity=", 0) == 0) {
+                        RawOptions::disk_affinity = parseCpuList("--disk-affinity", arg.substr(sizeof("--disk-affinity=") - 1));
+                        continue;
+                }
+                if (arg == "--disk-affinity") {
+                        if (i + 1 >= argc)
+                                throw std::runtime_error("--disk-affinity requires a value");
+                        RawOptions::disk_affinity = parseCpuList("--disk-affinity", argv[++i]);
+                        continue;
+                }
+
+                if (arg.rfind("--encode-nice=", 0) == 0) {
+                        RawOptions::encode_nice = parseNiceValue("--encode-nice", arg.substr(sizeof("--encode-nice=") - 1));
+                        continue;
+                }
+                if (arg == "--encode-nice") {
+                        if (i + 1 >= argc)
+                                throw std::runtime_error("--encode-nice requires a value");
+                        RawOptions::encode_nice = parseNiceValue("--encode-nice", argv[++i]);
+                        continue;
+                }
+
+                if (arg.rfind("--disk-nice=", 0) == 0) {
+                        RawOptions::disk_nice = parseNiceValue("--disk-nice", arg.substr(sizeof("--disk-nice=") - 1));
+                        continue;
+                }
+                if (arg == "--disk-nice") {
+                        if (i + 1 >= argc)
+                                throw std::runtime_error("--disk-nice requires a value");
+                        RawOptions::disk_nice = parseNiceValue("--disk-nice", argv[++i]);
+                        continue;
+                }
+
                 /* not a CinePi flag – forward it */
                 forward.push_back(argv[i]);
         }
@@ -180,6 +390,14 @@ bool CinePiOptions::Parse(int argc, char *argv[])
                      same_hdmi ? "true" : "false",
                      Zoom(),
                      scaler_crops_rects.size());
+
+        spdlog::info("cinepi-cli: encode_workers={} disk_workers={} encode_affinity={} disk_affinity={} encode_nice={} disk_nice={}",
+                      RawOptions::encode_workers,
+                      RawOptions::disk_workers,
+                      cpuListToString(RawOptions::encode_affinity),
+                      cpuListToString(RawOptions::disk_affinity),
+                      RawOptions::encode_nice ? std::to_string(*RawOptions::encode_nice) : std::string("auto"),
+                      RawOptions::disk_nice ? std::to_string(*RawOptions::disk_nice) : std::string("auto"));
 
         return ok;
 }

--- a/cinepi/dng_encoder.cpp
+++ b/cinepi/dng_encoder.cpp
@@ -16,8 +16,12 @@
  #include <iomanip>
  
  #include <sstream>                 
- #include <fstream>                 
- #include <regex>                   
+#include <algorithm>
+#include <fstream>
+#include <regex>
+#include <utility>
+#include <sched.h>
+#include <sys/resource.h>
  
  #include "dng_encoder.hpp"        
  #include "utils.hpp"               
@@ -252,43 +256,145 @@ Matrix(float m0, float m1, float m2,
 };
 
 #include <pthread.h>
+#include <cerrno>
 
 DngEncoder::DngEncoder(RawOptions const *options)
     : Encoder(options), // Assuming you're calling the base class constructor
       write12bit_(false),
       encoder_initialized_(false),
       encodeCheck_(false),
-      abortEncode_(false), 
-      abortOutput_(false), 
-      resetCount_(false), 
-      index_(0), 
-      frames_(0), 
+      resetCount_(false),
+      index_(0),
+      frames_(0),
       options_(options)
 {
-    console = spdlog::stdout_color_mt("dng_encoder");
+    console = spdlog::get("dng_encoder");
+    if (!console)
+        console = spdlog::stdout_color_mt("dng_encoder");
 
-    for (int i = 0; i < NUM_ENC_THREADS; i++){
-        encode_thread_[i] = std::thread(std::bind(&DngEncoder::encodeThread, this, i));
+    if (options_)
+    {
+        encode_worker_count_ = std::max<uint32_t>(1, options_->encode_workers);
+        disk_worker_count_   = std::max<uint32_t>(1, options_->disk_workers);
+        encode_affinity_     = options_->encode_affinity;
+        disk_affinity_       = options_->disk_affinity;
+        encode_nice_         = options_->encode_nice;
+        disk_nice_           = options_->disk_nice;
     }
-    for (int i = 0; i < NUM_DISK_THREADS; i++){
-        disk_thread_[i] = std::thread(std::bind(&DngEncoder::diskThread, this, i));
+    else
+    {
+        encode_worker_count_ = 2;
+        disk_worker_count_   = 8;
     }
 
-    console->info("DngEncoder started!");
+    encode_threads_.reserve(encode_worker_count_);
+    for (size_t i = 0; i < encode_worker_count_; ++i)
+        encode_threads_.emplace_back(&DngEncoder::encodeThread, this, static_cast<int>(i));
+
+    disk_threads_.reserve(disk_worker_count_);
+    for (size_t i = 0; i < disk_worker_count_; ++i)
+        disk_threads_.emplace_back(&DngEncoder::diskThread, this, static_cast<int>(i));
+
+    console->info("DngEncoder started with {} encode worker(s) and {} disk worker(s)",
+                  encode_worker_count_,
+                  disk_worker_count_);
 }
 
 DngEncoder::~DngEncoder()
 {
-    abortEncode_ = true;
-    for (int i = 0; i < NUM_ENC_THREADS; i++){
-        encode_thread_[i].join();
+    stopThreads();
+    console->info("DngEncoder stopped!");
+}
+
+void DngEncoder::stopThreads()
+{
+    bool encode_was_running = !stop_encode_.exchange(true, std::memory_order_acq_rel);
+    bool disk_was_running   = !stop_disk_.exchange(true, std::memory_order_acq_rel);
+
+    if (encode_was_running)
+        encode_cond_var_.notify_all();
+    if (disk_was_running)
+        disk_cond_var_.notify_all();
+
+    for (auto &thread : encode_threads_)
+    {
+        if (thread.joinable())
+            thread.join();
     }
-    for (int i = 0; i < NUM_DISK_THREADS; i++){
-        disk_thread_[i].join();
+    for (auto &thread : disk_threads_)
+    {
+        if (thread.joinable())
+            thread.join();
     }
 
-    abortOutput_ = true;
-    console->info("DngEncoder stopped!");
+    encode_threads_.clear();
+    disk_threads_.clear();
+}
+
+void DngEncoder::configureThreadContext(const std::string &baseName,
+                                        size_t index,
+                                        size_t total,
+                                        const std::optional<std::vector<int>> &affinity,
+                                        const std::optional<int> &nice_value)
+{
+    std::string name = baseName + std::to_string(index);
+    if (name.size() >= 16)
+        name.resize(15);
+
+    if (pthread_setname_np(pthread_self(), name.c_str()) != 0)
+    {
+        if (console)
+            console->warn("{}: failed to set thread name: {}", name, strerror(errno));
+    }
+
+    std::vector<int> cpus_to_pin;
+    if (affinity && !affinity->empty())
+    {
+        if (affinity->size() >= total)
+        {
+            cpus_to_pin.push_back((*affinity)[index % affinity->size()]);
+        }
+        else
+        {
+            cpus_to_pin.assign(affinity->begin(), affinity->end());
+        }
+
+        cpu_set_t cpu_mask;
+        CPU_ZERO(&cpu_mask);
+        for (int cpu : cpus_to_pin)
+            CPU_SET(cpu, &cpu_mask);
+
+        if (pthread_setaffinity_np(pthread_self(), sizeof(cpu_mask), &cpu_mask) != 0)
+        {
+            if (console)
+                console->warn("{}: failed to set CPU affinity: {}", name, strerror(errno));
+        }
+        else
+        {
+            std::ostringstream oss;
+            for (size_t i = 0; i < cpus_to_pin.size(); ++i)
+            {
+                if (i)
+                    oss << ',';
+                oss << cpus_to_pin[i];
+            }
+            if (console)
+                console->debug("{} pinned to CPU(s) {}", name, oss.str());
+        }
+    }
+
+    if (nice_value)
+    {
+        if (setpriority(PRIO_PROCESS, 0, *nice_value) != 0)
+        {
+            if (console)
+                console->warn("{}: failed to set nice level {}: {}", name, *nice_value, strerror(errno));
+        }
+        else if (console)
+        {
+            console->debug("{} nice level set to {}", name, *nice_value);
+        }
+    }
 }
 
 void DngEncoder::EncodeBuffer(int fd, size_t size, void *mem, StreamInfo const &info, int64_t timestamp_us)
@@ -305,10 +411,13 @@ void DngEncoder::EncodeBuffer(int fd, size_t size, void *mem, StreamInfo const &
 void DngEncoder::EncodeBuffer2(int fd, size_t size, void *mem, StreamInfo const &info, size_t losize, void *lomem, StreamInfo const &loinfo, int64_t timestamp_us, CompletedRequest::ControlList const &metadata)
 {
     {
+        if (stop_encode_.load(std::memory_order_acquire))
+            return;
+
         std::lock_guard<std::mutex> lock(encode_mutex_);
         EncodeItem item = { mem, size, info, lomem, losize, loinfo, metadata, timestamp_us, index_++ };
         encode_queue_.push(item);
-        encode_cond_var_.notify_all();
+        encode_cond_var_.notify_one();
     }
 }
 
@@ -718,7 +827,7 @@ size_t DngEncoder::dng_save([[maybe_unused]] int                /*thread_num*/,
 // ──────────────────────────────────────────────────────────────
 void DngEncoder::encodeThread(int num)
 {
-    std::chrono::duration<double> encode_time(0);
+    configureThreadContext("dng-enc-", static_cast<size_t>(num), encode_worker_count_, encode_affinity_, encode_nice_);
     EncodeItem encode_item;
 
     while (true)
@@ -726,16 +835,15 @@ void DngEncoder::encodeThread(int num)
         /* ──  Get the next job from the queue  ───────────────── */
         {
             std::unique_lock<std::mutex> lock(encode_mutex_);
-            while (true)
-            {
-                if (!encode_queue_.empty())
-                {
-                    encode_item = encode_queue_.front();
-                    encode_queue_.pop();
-                    break;
-                }
-                encode_cond_var_.wait_for(lock, 500us);
-            }
+            encode_cond_var_.wait(lock, [this] {
+                return stop_encode_.load(std::memory_order_acquire) || !encode_queue_.empty();
+            });
+
+            if (stop_encode_.load(std::memory_order_acquire) && encode_queue_.empty())
+                break;
+
+            encode_item = encode_queue_.front();
+            encode_queue_.pop();
         }
 
         frames_ = encode_item.index;
@@ -813,7 +921,7 @@ void DngEncoder::encodeThread(int num)
 
             std::lock_guard<std::mutex> lock(disk_mutex_);
             disk_buffer_.push(std::move(item));
-            disk_cond_var_.notify_all();
+            disk_cond_var_.notify_one();
         }
 
         auto end_time = std::chrono::high_resolution_clock::now();
@@ -834,29 +942,27 @@ void DngEncoder::encodeThread(int num)
 //Flushing data to disk
 void DngEncoder::diskThread(int num)
 {
+    configureThreadContext("dng-dsk-", static_cast<size_t>(num), disk_worker_count_, disk_affinity_, disk_nice_);
     DiskItem disk_item;
 
     while (true)
     {
         {
             std::unique_lock<std::mutex> lock(disk_mutex_);
-            while (true)
-            {
-                if (!disk_buffer_.empty())
-                {
-                    disk_item = disk_buffer_.front();
-                    disk_buffer_.pop();
-                    break;
-                }
-                else {
-                    disk_cond_var_.wait_for(lock, 1ms);
-                }
-            }
+            disk_cond_var_.wait(lock, [this] {
+                return stop_disk_.load(std::memory_order_acquire) || !disk_buffer_.empty();
+            });
+
+            if (stop_disk_.load(std::memory_order_acquire) && disk_buffer_.empty())
+                break;
+
+            disk_item = disk_buffer_.front();
+            disk_buffer_.pop();
         }
 
         std::ostringstream oss;
-        oss << options_->mediaDest << '/' 
-            << options_->folder << '/' 
+        oss << options_->mediaDest << '/'
+            << options_->folder << '/'
             << options_->folder << '_'
             << std::setw(9) << std::setfill('0') << disk_item.index 
             << ".dng";

--- a/cinepi/dng_encoder.hpp
+++ b/cinepi/dng_encoder.hpp
@@ -11,6 +11,7 @@
 #include <memory> // for std::shared_ptr
 #include <string>
 #include <atomic>
+#include <optional>
 
 #include <spdlog/spdlog.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
@@ -107,13 +108,16 @@ private:
 
 	std::shared_ptr<spdlog::logger> console;
 
-	static const int NUM_ENC_THREADS = 2;
-	static const int NUM_DISK_THREADS = 8;
+        void encodeThread(int num);
+        void diskThread(int num);
+        void stopThreads();
+        void configureThreadContext(const std::string &name,
+                                     size_t index,
+                                     size_t total,
+                                     const std::optional<std::vector<int>> &affinity,
+                                     const std::optional<int> &nice_value);
 
-	void encodeThread(int num);
-	void diskThread(int num);
-
-	bool encoder_initialized_;
+        bool encoder_initialized_;
 	struct DngInfo
 {
 	uint8_t bits;
@@ -168,18 +172,27 @@ private:
 	unsigned int max_buffer_frames;
 
 	bool encodeCheck_;
-	bool abortEncode_;
-	bool abortOutput_;
-	bool resetCount_;
-	uint64_t index_;
-	uint64_t frames_;
+        bool resetCount_;
+        uint64_t index_;
+        uint64_t frames_;
 
     RawOptions const *options_;
 
-	struct EncodeItem
-	{
+        size_t encode_worker_count_ { 0 };
+        size_t disk_worker_count_   { 0 };
+        std::vector<std::thread> encode_threads_;
+        std::vector<std::thread> disk_threads_;
+        std::atomic<bool> stop_encode_ { false };
+        std::atomic<bool> stop_disk_   { false };
+        std::optional<std::vector<int>> encode_affinity_;
+        std::optional<std::vector<int>> disk_affinity_;
+        std::optional<int> encode_nice_;
+        std::optional<int> disk_nice_;
 
-		void *mem;
+        struct EncodeItem
+        {
+
+                void *mem;
         size_t size;
 		StreamInfo info;
 		void *lomem;
@@ -191,8 +204,7 @@ private:
 	};
 	std::queue<EncodeItem> encode_queue_;
 	std::mutex encode_mutex_;
-	std::condition_variable encode_cond_var_;
-	std::thread encode_thread_[NUM_ENC_THREADS];
+        std::condition_variable encode_cond_var_;
 
         struct DiskItem
         {
@@ -204,10 +216,9 @@ private:
                 uint64_t index;
                 std::string timecode;
         };
-	std::queue<DiskItem> disk_buffer_;
-	std::mutex disk_mutex_;
-	std::condition_variable disk_cond_var_;
-	std::thread disk_thread_[NUM_DISK_THREADS];
+        std::queue<DiskItem> disk_buffer_;
+        std::mutex disk_mutex_;
+        std::condition_variable disk_cond_var_;
 };
 
 #endif

--- a/cinepi/raw_options.hpp
+++ b/cinepi/raw_options.hpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "core/video_options.hpp"
 
@@ -52,4 +53,12 @@ struct RawOptions : public VideoOptions
 
     /* keep full 16-bit raw instead of packing – NEW */
     bool keep16;                           // set by --keep16 in CinePiOptions
+
+    /* worker pool sizing + tuning */
+    uint32_t encode_workers { 2 };
+    uint32_t disk_workers   { 8 };
+    std::optional<std::vector<int>> encode_affinity;
+    std::optional<std::vector<int>> disk_affinity;
+    std::optional<int> encode_nice;
+    std::optional<int> disk_nice;
 };


### PR DESCRIPTION
## Summary
- document encoder and disk worker controls plus tuning examples in the README
- extend CinePi options parsing to accept worker counts, CPU affinities, and nice levels while logging the chosen values
- refactor the DNG encoder to size worker pools dynamically, apply thread naming/affinity/priority, and shut down cleanly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d987efeff08332957d6c377a199fb3