### PR TITLE
Handle disk write failures via callbacks and alerts

### DIFF
--- a/cinepi/cinepi_controller.cpp
+++ b/cinepi/cinepi_controller.cpp
@@ -17,6 +17,32 @@ using namespace std::chrono;
 #define CP_DEF_THUMBNAIL 1
 #define CP_DEF_THUMBNAIL_SIZE 3
 
+void CinePIController::notifyDiskWriteFailure(uint64_t frameIndex, const std::string &filename)
+{
+    console->error("Disk write failure for frame {} ({}).", frameIndex, filename);
+
+    Json::Value alert;
+    alert["type"] = "disk_write_failure";
+    alert["frame"] = static_cast<Json::UInt64>(frameIndex);
+    alert["file"] = filename;
+    alert["message"] = "Disk write dropped frame";
+
+    if (auto *encoder = app_->GetEncoder())
+        alert["failures"] = static_cast<Json::UInt64>(encoder->DiskFailureCount());
+
+    if (redis_)
+    {
+        try
+        {
+            redis_->publish(CHANNEL_ALERTS, alert.toStyledString());
+        }
+        catch (const sw::redis::Error &err)
+        {
+            console->error("Failed to publish disk write alert: {}", err.what());
+        }
+    }
+}
+
 void CinePIController::sync(){
     // getAllKeysAndValuesFromRedis();
 

--- a/cinepi/cinepi_controller.hpp
+++ b/cinepi/cinepi_controller.hpp
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <thread>
 #include <chrono>
+#include <string>
 
 //external dependancies
 #include <sw/redis++/redis++.h>
@@ -26,6 +27,7 @@
 #define CHANNEL_CONTROLS "cp_controls"
 #define CHANNEL_STATS "cp_stats"
 #define CHANNEL_HISTOGRAM "cp_histogram"
+#define CHANNEL_ALERTS "cp_alerts"
 
 #define REDIS_DEFAULT "redis://127.0.0.1:6379/0"
 
@@ -97,6 +99,8 @@ class CinePIController : public CinePIState
             redis_->set(CONTROL_KEY_WIDTH, std::to_string(cfg.size.width));
             redis_->set(CONTROL_KEY_HEIGHT, std::to_string(cfg.size.height));
         }
+
+        void notifyDiskWriteFailure(uint64_t frameIndex, const std::string &filename);
 
         bool folderOpen;
         bool cameraRunning;

--- a/cinepi/cinepi_raw.cpp
+++ b/cinepi/cinepi_raw.cpp
@@ -38,11 +38,14 @@ static void event_loop(CinePIRecorder &app, CinePIController &controller, CinePI
 	
 	CinePiOptions *options = app.GetOptions();
 
-	std::unique_ptr<Output> output = std::unique_ptr<Output>(Output::Create(options));
-	app.SetEncodeOutputReadyCallback(std::bind(&Output::OutputReady, output.get(), _1, _2, _3, _4));
-	app.SetMetadataReadyCallback(std::bind(&Output::MetadataReady, output.get(), _1));
+        std::unique_ptr<Output> output = std::unique_ptr<Output>(Output::Create(options));
+        app.SetEncodeOutputReadyCallback(std::bind(&Output::OutputReady, output.get(), _1, _2, _3, _4));
+        app.SetMetadataReadyCallback(std::bind(&Output::MetadataReady, output.get(), _1));
+        app.SetDiskErrorCallback([&controller](uint64_t frameIndex, const std::string &filename) {
+                controller.notifyDiskWriteFailure(frameIndex, filename);
+        });
 
-	app.OpenCamera();
+        app.OpenCamera();
         //app.ConfigureViewfinder();
 	app.StartEncoder();
 	std::vector<std::shared_ptr<libcamera::Camera>> cameras = app.GetCameras();

--- a/cinepi/cinepi_recorder.hpp
+++ b/cinepi/cinepi_recorder.hpp
@@ -20,6 +20,8 @@
 #include "preview/hdmi_utils.hpp"
 #include "preview/preview.hpp"
 
+#include <utility>
+
 
 typedef std::function<void(void *, size_t, int64_t, bool)> EncodeOutputReadyCallback;
 typedef std::function<void(libcamera::ControlList &)> MetadataReadyCallback;
@@ -33,16 +35,23 @@ public:
 	// CinePIRecorder() : RPiCamApp(std::make_unique<RawOptions>()) {}
 	CinePIRecorder() : RPiCamApp(std::make_unique<CinePiOptions>()) {}
 
-	void StartEncoder()
-	{
-		createEncoder();
-		encoder_->SetInputDoneCallback(std::bind(&CinePIRecorder::encodeBufferDone, this, std::placeholders::_1));
-		encoder_->SetOutputReadyCallback(encode_output_ready_callback_);
-	}
+        void StartEncoder()
+        {
+                createEncoder();
+                encoder_->SetInputDoneCallback(std::bind(&CinePIRecorder::encodeBufferDone, this, std::placeholders::_1));
+                encoder_->SetOutputReadyCallback(encode_output_ready_callback_);
+                encoder_->SetDiskErrorCallback(disk_error_callback_);
+        }
 	uint64_t last_timestamp_ns;
 	// This is callback when the encoder gives you the encoded output data.
-	void SetEncodeOutputReadyCallback(EncodeOutputReadyCallback callback) { encode_output_ready_callback_ = callback; }
-	void SetMetadataReadyCallback(MetadataReadyCallback callback) { metadata_ready_callback_ = callback; }
+        void SetEncodeOutputReadyCallback(EncodeOutputReadyCallback callback) { encode_output_ready_callback_ = callback; }
+        void SetMetadataReadyCallback(MetadataReadyCallback callback) { metadata_ready_callback_ = callback; }
+        void SetDiskErrorCallback(DngEncoder::DiskErrorCallback callback)
+        {
+                disk_error_callback_ = std::move(callback);
+                if (encoder_)
+                        encoder_->SetDiskErrorCallback(disk_error_callback_);
+        }
 	void EncodeBuffer(CompletedRequestPtr &completed_request, Stream *stream, Stream *lostream)
 	{
 		assert(encoder_);
@@ -126,7 +135,8 @@ private:
 
 	std::queue<CompletedRequestPtr> encode_buffer_queue_;
 	std::mutex encode_buffer_queue_mutex_;
-	EncodeOutputReadyCallback encode_output_ready_callback_;
-	MetadataReadyCallback metadata_ready_callback_;
+        EncodeOutputReadyCallback encode_output_ready_callback_;
+        MetadataReadyCallback metadata_ready_callback_;
+        DngEncoder::DiskErrorCallback disk_error_callback_;
 };
 #endif // CINEPI_RECORDER_HPP

--- a/cinepi/dng_encoder.cpp
+++ b/cinepi/dng_encoder.cpp
@@ -15,13 +15,14 @@
  #include <stdexcept>
  #include <iomanip>
  
- #include <sstream>                 
+ #include <sstream>
 #include <algorithm>
 #include <fstream>
 #include <regex>
 #include <utility>
 #include <sched.h>
 #include <sys/resource.h>
+ #include <cerrno>
  
  #include "dng_encoder.hpp"        
  #include "utils.hpp"               
@@ -256,7 +257,6 @@ Matrix(float m0, float m1, float m2,
 };
 
 #include <pthread.h>
-#include <cerrno>
 
 DngEncoder::DngEncoder(RawOptions const *options)
     : Encoder(options), // Assuming you're calling the base class constructor
@@ -304,6 +304,21 @@ DngEncoder::~DngEncoder()
 {
     stopThreads();
     console->info("DngEncoder stopped!");
+}
+
+void DngEncoder::SetDiskErrorCallback(DiskErrorCallback callback)
+{
+    disk_error_callback_ = std::move(callback);
+}
+
+DngEncoder::DiskErrorCallback DngEncoder::GetDiskErrorCallback() const
+{
+    return disk_error_callback_;
+}
+
+uint64_t DngEncoder::DiskFailureCount() const
+{
+    return disk_failures_.load(std::memory_order_relaxed);
 }
 
 void DngEncoder::stopThreads()
@@ -971,11 +986,11 @@ void DngEncoder::diskThread(int num)
     
         console->trace("Thread[{}]  Save frame to disk: {}", num, disk_item.index);
 
-        console->info("DNG written: {}", filename);
-        console->info("Timecode: {}", disk_item.timecode);
-        
         auto start_time = std::chrono::high_resolution_clock::now();
-        
+
+        bool disk_write_failed = false;
+        std::string failure_reason;
+
         // Use standard buffered IO instead of O_DIRECT
         int fd = open(filename.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
 
@@ -988,12 +1003,38 @@ void DngEncoder::diskThread(int num)
 
             // Always use actual used size returned by dng_save
             ssize_t bytes_written = write(fd, disk_item.mem_buf, disk_item.size);
-            if (bytes_written < 0 || static_cast<size_t>(bytes_written) != disk_item.size) {
-                perror("Error writing to file");
+            if (bytes_written < 0) {
+                int err = errno;
+                disk_write_failed = true;
+                failure_reason = std::string("write failed: ") + strerror(err);
+            } else if (static_cast<size_t>(bytes_written) != disk_item.size) {
+                disk_write_failed = true;
+                failure_reason = "partial write: wrote " +
+                    std::to_string(static_cast<long long>(bytes_written)) +
+                    " of " + std::to_string(static_cast<unsigned long long>(disk_item.size)) +
+                    " bytes";
+            } else {
+                console->info("DNG written: {}", filename);
+                console->info("Timecode: {}", disk_item.timecode);
             }
             close(fd);
         } else {
-            perror("Failed to open file for writing");
+            int err = errno;
+            disk_write_failed = true;
+            failure_reason = std::string("open failed: ") + strerror(err);
+        }
+
+        if (disk_write_failed) {
+            console->error("Thread[{}] frame {} disk write failure for '{}': {}",
+                           num,
+                           disk_item.index,
+                           filename,
+                           failure_reason);
+            console->error("Timecode (failed frame): {}", disk_item.timecode);
+            auto failures = disk_failures_.fetch_add(1, std::memory_order_relaxed) + 1;
+            console->error("Total disk write failures so far: {}", failures);
+            if (disk_error_callback_)
+                disk_error_callback_(disk_item.index, filename);
         }
 
         // Clean up

--- a/cinepi/dng_encoder.hpp
+++ b/cinepi/dng_encoder.hpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <atomic>
 #include <optional>
+#include <functional>
 
 #include <spdlog/spdlog.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
@@ -24,8 +25,10 @@
 class DngEncoder : public Encoder
 {
 public:
-	DngEncoder(RawOptions const *options);
-	~DngEncoder();
+        using DiskErrorCallback = std::function<void(uint64_t, const std::string &)>;
+
+        DngEncoder(RawOptions const *options);
+        ~DngEncoder();
 	
 	/* NEW – let the controller push µs-since-epoch for each frame */
     void setWallClockTimestamp(uint64_t us);   // µs since 1970-01-01
@@ -54,9 +57,13 @@ public:
 	int bufferSize(){
 		return disk_buffer_.size();
 	}
-	uint64_t getFrameCount(){
-		return frames_;
-	}
+        uint64_t getFrameCount(){
+                return frames_;
+        }
+
+        void SetDiskErrorCallback(DiskErrorCallback callback);
+        DiskErrorCallback GetDiskErrorCallback() const;
+        uint64_t DiskFailureCount() const;
 
 	uint16_t photometric;
 	uint16_t samples_per_pixel;
@@ -81,9 +88,9 @@ public:
 
 	bool mono_ = false;
 
-	std::vector<int64_t> timestamps;
-	std::array<uint8_t, 8> originationTimeCode;
-	std::array<uint16_t, 3> originationDate;
+        std::vector<int64_t> timestamps;
+        std::array<uint8_t, 8> originationTimeCode;
+        std::array<uint16_t, 3> originationDate;
 
 	/* ---- PUBLIC: number of frame buffers that fit in RAM ---- */
 	size_t maxRamBuffers() const { return max_ram_buffers_; }
@@ -106,7 +113,10 @@ private:
 
 	bool write12bit_{false};
 
-	std::shared_ptr<spdlog::logger> console;
+        std::shared_ptr<spdlog::logger> console;
+
+        DiskErrorCallback disk_error_callback_;
+        std::atomic<uint64_t> disk_failures_{0};
 
         void encodeThread(int num);
         void diskThread(int num);


### PR DESCRIPTION
## Summary
- add a disk write failure callback and counter to `DngEncoder` with accessors
- report failed opens/writes through the callback, logging, and the new counter, and forward the callback from `CinePIRecorder`
- surface disk write failures through `CinePIController` by publishing a Redis alert when frames are dropped

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e15d30d9b08332a77e0c656de7ef02