### PR TITLE
Fix sync policy type duplication for raw encoder

### DIFF
--- a/cinepi/cinepi_raw.cpp
+++ b/cinepi/cinepi_raw.cpp
@@ -41,7 +41,6 @@ static bool write_frame_file(const fs::path &path,
                              const std::vector<uint8_t> &buffer,
                              RawOptions const *options,
                              uint32_t frame_number,
-                             RawSyncPolicy policy,
                              RawOptions::SyncPolicy policy,
                              uint32_t sync_interval)
 {
@@ -127,7 +126,6 @@ static int run_selftest(CinePiOptions *options)
         for (size_t i = 0; i < frame_size; ++i)
                 buffer[i] = static_cast<uint8_t>(i & 0xFF);
 
-        RawSyncPolicy policy = options->sync_policy;
         RawOptions::SyncPolicy policy = options->sync_policy;
         uint32_t sync_interval = options->sync_interval ? options->sync_interval : 0;
 
@@ -143,7 +141,6 @@ static int run_selftest(CinePiOptions *options)
                 spdlog::info("selftest: frame {} took {} ms", i + 1, ms);
         }
 
-        if (policy == RawSyncPolicy::Take)
         if (policy == RawOptions::SyncPolicy::Take)
         {
                 int dir_fd = open(take_dir.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC);

--- a/cinepi/dng_encoder.cpp
+++ b/cinepi/dng_encoder.cpp
@@ -128,9 +128,6 @@ static const std::map<PixelFormat,int> mono_formats = {
     /* leave genuine true-mono formats here, e.g. GREY8 if you ever use it */
 };
 
-
-bool mono_ = false;   // add as a private member of DngEncoder
-
 void DngEncoder::setWallClockTimestamp(uint64_t us)
 {
     wallclock_ts_us_ = us;
@@ -319,7 +316,6 @@ DngEncoder::DngEncoder(RawOptions const *options)
         disk_nice_           = -5;
     }
 
-    if (sync_policy_ == RawSyncPolicy::Interval && sync_interval_ == 0)
     if (sync_policy_ == RawOptions::SyncPolicy::Interval && sync_interval_ == 0)
         sync_interval_ = 1;
 
@@ -477,7 +473,6 @@ void DngEncoder::disarmRecording()
 
     if (phase != StartupGate::Phase::Recording)
         clearPool();
-    else if (sync_policy_ == RawSyncPolicy::Take)
     else if (sync_policy_ == RawOptions::SyncPolicy::Take)
         pending_take_sync_.store(true, std::memory_order_release);
 

--- a/cinepi/dng_encoder.hpp
+++ b/cinepi/dng_encoder.hpp
@@ -100,11 +100,6 @@ public:
 
         bool mono_ = false;
 
-
-        StageMetrics snapshotStageMetrics() const;
-
-        bool mono_ = false;
-
         std::vector<int64_t> timestamps;
         std::array<uint8_t, 8> originationTimeCode;
         std::array<uint16_t, 3> originationDate;
@@ -252,7 +247,6 @@ private:
         std::atomic<uint64_t> last_disk_us_{0};
         std::atomic<size_t>   queue_depth_{0};
 
-        RawSyncPolicy sync_policy_ { RawSyncPolicy::Never };
         RawOptions::SyncPolicy sync_policy_ { RawOptions::SyncPolicy::Never };
         uint32_t sync_interval_ { 0 };
         bool drop_cache_after_close_ { false };

--- a/cinepi/raw_options.hpp
+++ b/cinepi/raw_options.hpp
@@ -57,12 +57,6 @@ struct RawOptions : public VideoOptions
 
     /* worker pool sizing + tuning */
     using SyncPolicy = RawSyncPolicy;
-    enum class SyncPolicy
-    {
-        Never,
-        Take,
-        Interval
-    };
 
     uint32_t encode_workers { 4 };
     uint32_t disk_workers   { 2 };
@@ -77,9 +71,6 @@ struct RawOptions : public VideoOptions
     uint32_t ignore_start_frames { 12 };
 
     /* disk synchronisation ---------------------------------------------- */
-    using SyncPolicy = RawSyncPolicy;
-
-    RawSyncPolicy sync_policy { RawSyncPolicy::Never };
     SyncPolicy sync_policy { SyncPolicy::Never };
     uint32_t   sync_interval { 0 };      // used when policy == Interval
     bool       drop_cache_after_close { false };

--- a/cinepi/sync_utils.hpp
+++ b/cinepi/sync_utils.hpp
@@ -7,13 +7,6 @@ inline bool should_sync_frame(RawSyncPolicy policy,
                               uint64_t frame_number)
 {
     if (policy == RawSyncPolicy::Interval && interval)
-#include "raw_options.hpp"
-
-inline bool should_sync_frame(RawOptions::SyncPolicy policy,
-                              uint32_t interval,
-                              uint64_t frame_number)
-{
-    if (policy == RawOptions::SyncPolicy::Interval && interval)
         return (frame_number % interval) == 0;
     return false;
 }

--- a/cinepi/tests/test_sync_policy.cpp
+++ b/cinepi/tests/test_sync_policy.cpp
@@ -1,5 +1,6 @@
 #include "sync_utils.hpp"
 #include "sync_policy.hpp"
+#include "raw_options.hpp"
 
 #include <cassert>
 


### PR DESCRIPTION
## Summary
- remove the redundant sync policy enum declarations from raw options and the DNG encoder header
- simplify the sync utility helper to accept the shared RawSyncPolicy enum and include RawOptions only where needed
- update the DNG encoder and cinepi_raw self-test to rely on the unified sync policy alias

## Testing
- `g++ -std=c++17 -Icinepi -I. -I.. -c cinepi/tests/test_sync_policy.cpp -o /tmp/test_sync_policy.o` *(fails: missing boost/program_options.hpp in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68eff43161a88332afdcd49a5e6ba787