### PR TITLE
Fix sync policy parsing in CinePi options

### DIFF
--- a/cinepi/cinepi_options.cpp
+++ b/cinepi/cinepi_options.cpp
@@ -179,7 +179,6 @@ static unsigned int parseUnsignedOption(const std::string &flag,
         }
 }
 
-static RawSyncPolicy parseSyncPolicy(const std::string &flag,
 static RawOptions::SyncPolicy parseSyncPolicy(const std::string &flag,
                                               const std::string &value,
                                               RawOptions &options)
@@ -195,13 +194,11 @@ static RawOptions::SyncPolicy parseSyncPolicy(const std::string &flag,
         if (lower == "never")
         {
                 options.sync_interval = 0;
-                return RawSyncPolicy::Never;
                 return RawOptions::SyncPolicy::Never;
         }
         if (lower == "take")
         {
                 options.sync_interval = 0;
-                return RawSyncPolicy::Take;
                 return RawOptions::SyncPolicy::Take;
         }
         if (lower.rfind("interval", 0) == 0)
@@ -209,22 +206,12 @@ static RawOptions::SyncPolicy parseSyncPolicy(const std::string &flag,
                 size_t pos = lower.find_first_of("=:");
                 if (pos != std::string::npos)
                         setInterval(lower.substr(pos + 1));
-                return RawSyncPolicy::Interval;
                 return RawOptions::SyncPolicy::Interval;
         }
 
         throw std::runtime_error(flag + " must be one of never, take, interval[=N]");
 }
 
-static const char *syncPolicyName(RawSyncPolicy policy)
-{
-        switch (policy)
-        {
-        case RawSyncPolicy::Never:
-                return "never";
-        case RawSyncPolicy::Take:
-                return "take";
-        case RawSyncPolicy::Interval:
 static const char *syncPolicyName(RawOptions::SyncPolicy policy)
 {
         switch (policy)
@@ -518,7 +505,6 @@ bool CinePiOptions::Parse(int argc, char *argv[])
 
                 if (arg.rfind("--sync-interval=", 0) == 0) {
                         RawOptions::sync_interval = parseUnsignedOption("--sync-interval", arg.substr(sizeof("--sync-interval=") - 1), 1);
-                        RawOptions::sync_policy = RawSyncPolicy::Interval;
                         RawOptions::sync_policy = RawOptions::SyncPolicy::Interval;
                         continue;
                 }
@@ -526,7 +512,6 @@ bool CinePiOptions::Parse(int argc, char *argv[])
                         if (i + 1 >= argc)
                                 throw std::runtime_error("--sync-interval requires a value");
                         RawOptions::sync_interval = parseUnsignedOption("--sync-interval", argv[++i], 1);
-                        RawOptions::sync_policy = RawSyncPolicy::Interval;
                         RawOptions::sync_policy = RawOptions::SyncPolicy::Interval;
                         continue;
                 }


### PR DESCRIPTION
## Summary
- fix the sync policy parsing helper to return the correct RawOptions::SyncPolicy values
- remove leftover RawSyncPolicy references and ensure --sync-interval sets the new policy enum

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68eff6530ba08332bc29364859c9faa9