### PR TITLE
Include StartupGate implementation in builds

### DIFF
--- a/cinepi/meson.build
+++ b/cinepi/meson.build
@@ -24,6 +24,7 @@ endif
 sources = [
   'cinepi_raw.cpp',
   'dng_encoder.cpp',
+  'startup_gate.cpp',
   'sharedContextStage.cpp',
   'mjpegPreviewStage.cpp',
   'cinepi_controller.cpp',

--- a/cinepi/tests/meson.build
+++ b/cinepi/tests/meson.build
@@ -1,5 +1,5 @@
 startup_gate_test = executable('startup_gate_test',
-    'test_startup_gate.cpp',
+    ['test_startup_gate.cpp', '../startup_gate.cpp'],
     include_directories : [include_directories('..')],
     dependencies : [spdlog_dep])
 


### PR DESCRIPTION
## Summary
- add the StartupGate implementation to the cinepi target sources
- compile the StartupGate unit test with the implementation file so linking succeeds

## Testing
- meson setup build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68eff7a437e48332b84b34ef7a57effe