### PR TITLE
Fix sync_policy test include paths

### DIFF
--- a/cinepi/tests/meson.build
+++ b/cinepi/tests/meson.build
@@ -7,6 +7,6 @@ test('startup_gate', startup_gate_test)
 
 sync_policy_test = executable('sync_policy_test',
     'test_sync_policy.cpp',
-    include_directories : [include_directories('..')])
+    include_directories : [include_directories('..', '../../core')])
 
 test('sync_policy', sync_policy_test)


### PR DESCRIPTION
## Summary
- add the core directory to the sync_policy_test include paths so the shared headers resolve correctly

## Testing
- not run (meson executable not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68eff8aed21c83329cd5c1b0f86ac266