### PR TITLE
Fix sync policy test include paths

### DIFF
--- a/cinepi/tests/meson.build
+++ b/cinepi/tests/meson.build
@@ -7,6 +7,6 @@ test('startup_gate', startup_gate_test)
 
 sync_policy_test = executable('sync_policy_test',
     'test_sync_policy.cpp',
-    include_directories : [include_directories('..', '../../core')])
+    include_directories : [include_directories('..', '../..')])
 
 test('sync_policy', sync_policy_test)


### PR DESCRIPTION
## Summary
- add the repository root to the sync policy test include directories so headers under core/ resolve correctly

## Testing
- not run (meson is not available in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68effbf27ff88332a3e0a2095e870f43