### PR TITLE
Handle libcamera umbrella header

### DIFF
--- a/core/options.hpp
+++ b/core/options.hpp
@@ -14,7 +14,15 @@
 
 #include <boost/program_options.hpp>
 
+#if defined(__has_include)
+#if __has_include(<libcamera/libcamera.h>)
+#include <libcamera/libcamera.h>
+#else
 #include <libcamera/camera.h>
+#endif
+#else
+#include <libcamera/camera.h>
+#endif
 #include <libcamera/camera_manager.h>
 #include <libcamera/control_ids.h>
 #include <libcamera/property_ids.h>

--- a/core/rpicam_app.hpp
+++ b/core/rpicam_app.hpp
@@ -22,7 +22,15 @@
 #include <vector>
 
 #include <libcamera/base/span.h>
+#if defined(__has_include)
+#if __has_include(<libcamera/libcamera.h>)
+#include <libcamera/libcamera.h>
+#else
 #include <libcamera/camera.h>
+#endif
+#else
+#include <libcamera/camera.h>
+#endif
 #include <libcamera/camera_manager.h>
 #include <libcamera/control_ids.h>
 #include <libcamera/controls.h>


### PR DESCRIPTION
## Summary
- include the libcamera umbrella header when available to cover renamed headers
- fall back to the previous camera.h include for older libcamera installations
- update both options.hpp and rpicam_app.hpp to use the conditional include

## Testing
- not run (header-only change)


------
https://chatgpt.com/codex/tasks/task_e_68effd5730d48332ae7b5704bc3afc5f