### PR TITLE
Ensure recording resumes with a key frame

### DIFF
--- a/apps/rpicam_raw.cpp
+++ b/apps/rpicam_raw.cpp
@@ -27,10 +27,11 @@ protected:
 
 static void event_loop(LibcameraRaw &app)
 {
-	VideoOptions const *options = app.GetOptions();
-	std::unique_ptr<Output> output = std::unique_ptr<Output>(Output::Create(options));
-	app.SetEncodeOutputReadyCallback(std::bind(&Output::OutputReady, output.get(), _1, _2, _3, _4));
-	app.SetMetadataReadyCallback(std::bind(&Output::MetadataReady, output.get(), _1));
+        VideoOptions const *options = app.GetOptions();
+        std::unique_ptr<Output> output = std::unique_ptr<Output>(Output::Create(options));
+        output->SetRequestKeyFrameCallback(std::bind(&RPiCamEncoder::RequestKeyFrame, &app));
+        app.SetEncodeOutputReadyCallback(std::bind(&Output::OutputReady, output.get(), _1, _2, _3, _4));
+        app.SetMetadataReadyCallback(std::bind(&Output::MetadataReady, output.get(), _1));
 
 	app.OpenCamera();
 	app.ConfigureVideo(LibcameraRaw::FLAG_VIDEO_RAW);

--- a/apps/rpicam_vid.cpp
+++ b/apps/rpicam_vid.cpp
@@ -64,10 +64,11 @@ static int get_colourspace_flags(std::string const &codec)
 
 static void event_loop(RPiCamEncoder &app)
 {
-	VideoOptions const *options = app.GetOptions();
-	std::unique_ptr<Output> output = std::unique_ptr<Output>(Output::Create(options));
-	app.SetEncodeOutputReadyCallback(std::bind(&Output::OutputReady, output.get(), _1, _2, _3, _4));
-	app.SetMetadataReadyCallback(std::bind(&Output::MetadataReady, output.get(), _1));
+        VideoOptions const *options = app.GetOptions();
+        std::unique_ptr<Output> output = std::unique_ptr<Output>(Output::Create(options));
+        output->SetRequestKeyFrameCallback(std::bind(&RPiCamEncoder::RequestKeyFrame, &app));
+        app.SetEncodeOutputReadyCallback(std::bind(&Output::OutputReady, output.get(), _1, _2, _3, _4));
+        app.SetMetadataReadyCallback(std::bind(&Output::MetadataReady, output.get(), _1));
 
 	app.OpenCamera();
 	app.ConfigureVideo(get_colourspace_flags(options->codec));

--- a/core/rpicam_encoder.hpp
+++ b/core/rpicam_encoder.hpp
@@ -42,14 +42,19 @@ public:
 			cl.set(libcamera::controls::rpi::SyncMode, libcamera::controls::rpi::SyncModeClient);
 		SetControls(cl);
 	}
-	// This is callback when the encoder gives you the encoded output data.
-	void SetEncodeOutputReadyCallback(EncodeOutputReadyCallback callback) { encode_output_ready_callback_ = callback; }
-	void SetMetadataReadyCallback(MetadataReadyCallback callback) { metadata_ready_callback_ = callback; }
-	bool EncodeBuffer(CompletedRequestPtr &completed_request, Stream *stream)
-	{
-		assert(encoder_);
+        // This is callback when the encoder gives you the encoded output data.
+        void SetEncodeOutputReadyCallback(EncodeOutputReadyCallback callback) { encode_output_ready_callback_ = callback; }
+        void SetMetadataReadyCallback(MetadataReadyCallback callback) { metadata_ready_callback_ = callback; }
+        void RequestKeyFrame()
+        {
+                if (encoder_)
+                        encoder_->RequestKeyFrame();
+        }
+        bool EncodeBuffer(CompletedRequestPtr &completed_request, Stream *stream)
+        {
+                assert(encoder_);
 
-		// If sync was enabled, and SyncReady is still "false" then we must skip this frame. Tell our
+                // If sync was enabled, and SyncReady is still "false" then we must skip this frame. Tell our
 		// caller through the return value that we're not yet encoding anything.
 		if (GetOptions()->sync && !completed_request->metadata.get(controls::rpi::SyncReady).value_or(false))
 			return false;

--- a/encoder/encoder.hpp
+++ b/encoder/encoder.hpp
@@ -18,23 +18,24 @@ typedef std::function<void(void *, size_t, int64_t, bool)> OutputReadyCallback;
 class Encoder
 {
 public:
-	static Encoder *Create(VideoOptions *options, StreamInfo const &info);
+        static Encoder *Create(VideoOptions *options, StreamInfo const &info);
 
-	Encoder(VideoOptions const *options) : options_(options) {}
-	virtual ~Encoder() {}
-	// This is where the application sets the callback it gets whenever the encoder
-	// has finished with an input buffer, so the application can re-use it.
-	void SetInputDoneCallback(InputDoneCallback callback) { input_done_callback_ = callback; }
-	// This callback is how the application is told that an encoded buffer is
-	// available. The application may not hang on to the memory once it returns
-	// (but the callback is already running in its own thread).
-	void SetOutputReadyCallback(OutputReadyCallback callback) { output_ready_callback_ = callback; }
-	// Encode the given buffer. The buffer is specified both by an fd and size
-	// describing a DMABUF, and by a mmapped userland pointer.
-	virtual void EncodeBuffer(int fd, size_t size, void *mem, StreamInfo const &info, int64_t timestamp_us) = 0;
+        Encoder(VideoOptions const *options) : options_(options) {}
+        virtual ~Encoder() {}
+        // This is where the application sets the callback it gets whenever the encoder
+        // has finished with an input buffer, so the application can re-use it.
+        void SetInputDoneCallback(InputDoneCallback callback) { input_done_callback_ = callback; }
+        // This callback is how the application is told that an encoded buffer is
+        // available. The application may not hang on to the memory once it returns
+        // (but the callback is already running in its own thread).
+        void SetOutputReadyCallback(OutputReadyCallback callback) { output_ready_callback_ = callback; }
+        // Encode the given buffer. The buffer is specified both by an fd and size
+        // describing a DMABUF, and by a mmapped userland pointer.
+        virtual void EncodeBuffer(int fd, size_t size, void *mem, StreamInfo const &info, int64_t timestamp_us) = 0;
+        virtual void RequestKeyFrame() {}
 
 protected:
-	InputDoneCallback input_done_callback_;
-	OutputReadyCallback output_ready_callback_;
-	VideoOptions const *options_;
+        InputDoneCallback input_done_callback_;
+        OutputReadyCallback output_ready_callback_;
+        VideoOptions const *options_;
 };

--- a/encoder/h264_encoder.cpp
+++ b/encoder/h264_encoder.cpp
@@ -207,10 +207,10 @@ H264Encoder::H264Encoder(VideoOptions const *options, StreamInfo const &info)
 
 H264Encoder::~H264Encoder()
 {
-	abortPoll_ = true;
-	poll_thread_.join();
-	abortOutput_ = true;
-	output_thread_.join();
+        abortPoll_ = true;
+        poll_thread_.join();
+        abortOutput_ = true;
+        output_thread_.join();
 
 	// Turn off streaming on both the output and capture queues, and "free" the
 	// buffers that we requested. The capture ones need to be "munmapped" first.
@@ -239,15 +239,23 @@ H264Encoder::~H264Encoder()
 	if (xioctl(fd_, VIDIOC_REQBUFS, &reqbufs) < 0)
 		LOG(1, "Request to free capture buffers failed");
 
-	close(fd_);
-	LOG(2, "H264Encoder closed");
+        close(fd_);
+        LOG(2, "H264Encoder closed");
+}
+
+void H264Encoder::RequestKeyFrame()
+{
+        v4l2_control ctrl = {};
+        ctrl.id = V4L2_CID_MPEG_VIDEO_FORCE_KEY_FRAME;
+        if (xioctl(fd_, VIDIOC_S_CTRL, &ctrl) < 0)
+                LOG(1, "Failed to force key frame");
 }
 
 void H264Encoder::EncodeBuffer(int fd, size_t size, void *mem, StreamInfo const &info, int64_t timestamp_us)
 {
-	int index;
-	{
-		// We need to find an available output buffer (input to the codec) to
+        int index;
+        {
+                // We need to find an available output buffer (input to the codec) to
 		// "wrap" the DMABUF.
 		std::lock_guard<std::mutex> lock(input_buffers_available_mutex_);
 		if (input_buffers_available_.empty())

--- a/encoder/h264_encoder.hpp
+++ b/encoder/h264_encoder.hpp
@@ -17,10 +17,11 @@
 class H264Encoder : public Encoder
 {
 public:
-	H264Encoder(VideoOptions const *options, StreamInfo const &info);
-	~H264Encoder();
-	// Encode the given DMABUF.
-	void EncodeBuffer(int fd, size_t size, void *mem, StreamInfo const &info, int64_t timestamp_us) override;
+        H264Encoder(VideoOptions const *options, StreamInfo const &info);
+        ~H264Encoder();
+        // Encode the given DMABUF.
+        void EncodeBuffer(int fd, size_t size, void *mem, StreamInfo const &info, int64_t timestamp_us) override;
+        void RequestKeyFrame() override;
 
 private:
 	// We want at least as many output buffers as there are in the camera queue

--- a/output/output.cpp
+++ b/output/output.cpp
@@ -41,20 +41,30 @@ Output::Output(VideoOptions const *options)
 
 Output::~Output()
 {
-	if (fp_timestamps_)
-		fclose(fp_timestamps_);
-	if (!options_->metadata.empty())
-		stop_metadata_output(buf_metadata_, options_->metadata_format);
+        if (fp_timestamps_)
+                fclose(fp_timestamps_);
+        if (!options_->metadata.empty())
+                stop_metadata_output(buf_metadata_, options_->metadata_format);
+}
+
+void Output::SetRequestKeyFrameCallback(std::function<void()> callback)
+{
+        request_keyframe_callback_ = callback;
+        if (request_keyframe_callback_ && enable_.load())
+                request_keyframe_callback_();
 }
 
 void Output::Signal()
 {
-	enable_ = !enable_;
+        bool new_state = !enable_.load();
+        enable_ = new_state;
+        if (new_state && request_keyframe_callback_)
+                request_keyframe_callback_();
 }
 
 void Output::OutputReady(void *mem, size_t size, int64_t timestamp_us, bool keyframe)
 {
-	// When output is enabled, we may have to wait for the next keyframe.
+        // When output is enabled, we may have to wait for the next keyframe.
 	uint32_t flags = keyframe ? FLAG_KEYFRAME : FLAG_NONE;
 	if (!enable_)
 		state_ = DISABLED;

--- a/output/output.hpp
+++ b/output/output.hpp
@@ -10,19 +10,21 @@
 #include <cstdio>
 
 #include <atomic>
+#include <functional>
 
 #include "core/video_options.hpp"
 
 class Output
 {
 public:
-	static Output *Create(VideoOptions const *options);
+        static Output *Create(VideoOptions const *options);
 
-	Output(VideoOptions const *options);
-	virtual ~Output();
-	virtual void Signal(); // a derived class might redefine what this means
-	void OutputReady(void *mem, size_t size, int64_t timestamp_us, bool keyframe);
-	void MetadataReady(libcamera::ControlList &metadata);
+        Output(VideoOptions const *options);
+        virtual ~Output();
+        virtual void Signal(); // a derived class might redefine what this means
+        void SetRequestKeyFrameCallback(std::function<void()> callback);
+        void OutputReady(void *mem, size_t size, int64_t timestamp_us, bool keyframe);
+        void MetadataReady(libcamera::ControlList &metadata);
 
 protected:
 	enum Flag
@@ -48,9 +50,10 @@ private:
 	int64_t time_offset_;
 	int64_t last_timestamp_;
 	std::streambuf *buf_metadata_;
-	std::ofstream of_metadata_;
-	bool metadata_started_ = false;
-	std::queue<libcamera::ControlList> metadata_queue_;
+        std::ofstream of_metadata_;
+        bool metadata_started_ = false;
+        std::queue<libcamera::ControlList> metadata_queue_;
+        std::function<void()> request_keyframe_callback_;
 };
 
 void start_metadata_output(std::streambuf *buf, std::string fmt);


### PR DESCRIPTION
## Summary
- add a RequestKeyFrame hook to Encoder and implement it for the V4L2 H.264 backend
- expose a request-key-frame helper through RPiCamEncoder and Output, triggering it on resume/start
- wire recorder applications to request a key frame when Output is enabled so recording restarts cleanly

## Testing
- meson setup build *(fails: meson not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f14d7559088332a9b120fafcc2b0c6