### PR TITLE
Enable sensor HDR for IMX585

### DIFF
--- a/core/options.cpp
+++ b/core/options.cpp
@@ -207,9 +207,9 @@ bool Options::Parse(int argc, char *argv[])
 	std::vector<std::shared_ptr<libcamera::Camera>> cameras = app_->GetCameras();
 	if (camera < cameras.size())
 	{
-		const std::string cam_id = *cameras[camera]->properties().get(libcamera::properties::Model);
-		if ((hdr == "sensor" || hdr == "auto") && cam_id == "imx708")
-		{
+                const std::string cam_id = *cameras[camera]->properties().get(libcamera::properties::Model);
+                if ((hdr == "sensor" || hdr == "auto") && (cam_id == "imx708" || cam_id == "imx585"))
+                {
 			// Turn on sensor HDR.  Reset the camera manager if we have switched the value of the control.
 			if (set_subdev_hdr_ctrl(1))
 			{

--- a/core/options.cpp
+++ b/core/options.cpp
@@ -104,8 +104,16 @@ static int xioctl(int fd, unsigned long ctl, void *arg)
 	return ret;
 }
 
-static bool set_subdev_hdr_ctrl(int en)
+enum class HdrCtrlResult
 {
+	Unsupported,
+	Unchanged,
+	Changed,
+};
+
+static HdrCtrlResult set_subdev_hdr_ctrl(int en)
+{
+	bool supported = false;
 	bool changed = false;
 	// Currently this does not exist in libcamera, so go directly to V4L2
 	// XXX it's not obvious which v4l2-subdev to use for which camera!
@@ -118,15 +126,21 @@ static bool set_subdev_hdr_ctrl(int en)
 			continue;
 
 		v4l2_control ctrl { V4L2_CID_WIDE_DYNAMIC_RANGE, en };
-		if (!xioctl(fd, VIDIOC_G_CTRL, &ctrl) && ctrl.value != en)
+		if (!xioctl(fd, VIDIOC_G_CTRL, &ctrl))
 		{
-			ctrl.value = en;
-			if (!xioctl(fd, VIDIOC_S_CTRL, &ctrl))
-				changed = true;
+			supported = true;
+			if (ctrl.value != en)
+			{
+				ctrl.value = en;
+				if (!xioctl(fd, VIDIOC_S_CTRL, &ctrl))
+					changed = true;
+			}
 		}
 		close(fd);
 	}
-	return changed;
+	if (!supported)
+		return HdrCtrlResult::Unsupported;
+	return changed ? HdrCtrlResult::Changed : HdrCtrlResult::Unchanged;
 }
 
 bool Options::Parse(int argc, char *argv[])
@@ -207,17 +221,24 @@ bool Options::Parse(int argc, char *argv[])
 	std::vector<std::shared_ptr<libcamera::Camera>> cameras = app_->GetCameras();
 	if (camera < cameras.size())
 	{
-                const std::string cam_id = *cameras[camera]->properties().get(libcamera::properties::Model);
-                if ((hdr == "sensor" || hdr == "auto") && (cam_id == "imx708" || cam_id == "imx585"))
-                {
+		const std::string cam_id = *cameras[camera]->properties().get(libcamera::properties::Model);
+		const bool is_imx585 = cam_id == "imx585" || cam_id == "imx585_mono";
+		if ((hdr == "sensor" || hdr == "auto") && (cam_id == "imx708" || is_imx585))
+		{
 			// Turn on sensor HDR.  Reset the camera manager if we have switched the value of the control.
-			if (set_subdev_hdr_ctrl(1))
+			HdrCtrlResult hdr_result = set_subdev_hdr_ctrl(1);
+			if (hdr_result == HdrCtrlResult::Unsupported)
+			{
+				LOG_ERROR("Sensor HDR requested but wide_dynamic_range control not found on any subdevice");
+			}
+			if (hdr_result == HdrCtrlResult::Changed)
 			{
 				cameras.clear();
 				app_->initCameraManager();
 				cameras = app_->GetCameras();
 			}
-			hdr = "sensor";
+			if (hdr_result != HdrCtrlResult::Unsupported)
+				hdr = "sensor";
 		}
 	}
 

--- a/core/options.hpp
+++ b/core/options.hpp
@@ -207,7 +207,7 @@ struct Options
 			 "Set the lens to a particular focus position, expressed as a reciprocal distance (0 moves the lens to infinity), or \"default\" for the hyperfocal distance")
                         ("hdr", value<std::string>(&hdr)->default_value("off")->implicit_value("auto"),
                          "Enable High Dynamic Range, where supported. Available values are \"off\", \"auto\", "
-                         "\"sensor\" for sensor HDR (e.g. Camera Module 3 or IMX585), "
+                         "\"sensor\" for sensor HDR (e.g. Camera Module 3 or IMX585 colour/mono), "
                          "\"single-exp\" for PiSP based single exposure multiframe HDR")
 			("metadata", value<std::string>(&metadata),
 			 "Save captured image metadata to a file or \"-\" for stdout")

--- a/core/options.hpp
+++ b/core/options.hpp
@@ -205,10 +205,10 @@ struct Options
 			"Sets AfMetering to  AfMeteringWindows an set region used, e.g. 0.25,0.25,0.5,0.5")
 			("lens-position", value<std::string>(&lens_position_)->default_value(""),
 			 "Set the lens to a particular focus position, expressed as a reciprocal distance (0 moves the lens to infinity), or \"default\" for the hyperfocal distance")
-			("hdr", value<std::string>(&hdr)->default_value("off")->implicit_value("auto"),
-			 "Enable High Dynamic Range, where supported. Available values are \"off\", \"auto\", "
-			 "\"sensor\" for sensor HDR (e.g. for Camera Module 3), "
-			 "\"single-exp\" for PiSP based single exposure multiframe HDR")
+                        ("hdr", value<std::string>(&hdr)->default_value("off")->implicit_value("auto"),
+                         "Enable High Dynamic Range, where supported. Available values are \"off\", \"auto\", "
+                         "\"sensor\" for sensor HDR (e.g. Camera Module 3 or IMX585), "
+                         "\"single-exp\" for PiSP based single exposure multiframe HDR")
 			("metadata", value<std::string>(&metadata),
 			 "Save captured image metadata to a file or \"-\" for stdout")
 			("metadata-format", value<std::string>(&metadata_format)->default_value("json"),


### PR DESCRIPTION
## Summary
- allow the IMX585 camera model to enable sensor HDR using the existing wide dynamic range toggle
- update the HDR CLI help text to note IMX585 support alongside the Camera Module 3

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f92af5fedc8332a638ef8e398df1ce