### PR TITLE
Fix compiler warnings

### DIFF
--- a/cinepi/cinepi_controller.cpp
+++ b/cinepi/cinepi_controller.cpp
@@ -225,7 +225,6 @@ void CinePIController::process(CompletedRequestPtr &completed_request)
     {
         /* Derive once-per-run offset between MONOTONIC and REALTIME */
         using clk_sys  = std::chrono::system_clock;
-        using clk_mono = std::chrono::steady_clock;      // same epoch as SensorTimestamp
 
         static bool     have_offset   = false;
         static uint64_t boot0_ns      = 0;               // first sensor ts (ns)

--- a/cinepi/cinepi_controller.hpp
+++ b/cinepi/cinepi_controller.hpp
@@ -34,15 +34,15 @@ using namespace sw::redis;
 class CinePIController : public CinePIState
 {
     public:
-        CinePIController(CinePIRecorder *app) 
-            : CinePIState(), 
-            app_(app),
+        CinePIController(CinePIRecorder *app)
+            : CinePIState(),
             folderOpen(false),
             cameraRunning(false),
             trigger_(0),
-            options_(app->GetOptions()), 
-            cameraInit_(true), 
-            abortThread_(false) 
+            cameraInit_(true),
+            app_(app),
+            options_(app->GetOptions()),
+            abortThread_(false)
         {
             console = spdlog::stdout_color_mt("cinepi_controller");
         };

--- a/cinepi/cinepi_sound.cpp
+++ b/cinepi/cinepi_sound.cpp
@@ -121,26 +121,32 @@ uint64_t extractTime(const std::string& line) {
     return (seconds * 1e+9) + nanoseconds;
 }
 
-CinePISound::CinePISound(CinePIRecorder *app) : 
-    app_(app),
-    pid(-1),
-    abortThread_(false),
+CinePISound::CinePISound(CinePIRecorder *app) :
+    vu_meter({0, 0, 0, 0}),
+    samples_captured(0),
+    ts_start(0),
+    ts_first_buffer_b(0),
+    ts_first_buffer_a(0),
+    ts_close_file(0),
+    ts_end(0),
+    audioFormat("S16_LE"),
+    audioChannels(1),
+    audioSampleRate(FIXED_AUDIO_SAMPLE_RATE),
     arec_pipe(nullptr),
+    canRecordAudio(false),
+    defaultDevice(""),
+    console(nullptr),
+    pid(-1),
+    recording_(false),
+    record_(false),
+    app_(app),
+    options_(app->GetOptions()),
+    abortThread_(false),
+    monitor_pipe(nullptr),
     udev(nullptr),
     udev_dev(nullptr),
     udev_mon(nullptr),
-    udev_fd(-1),
-    vu_meter({0,0,0,0}),
-    samples_captured(0),
-    ts_first_buffer_b(0),
-    record_(false),
-    recording_(false),
-    canRecordAudio(false),
-    defaultDevice(""),
-    options_(app->GetOptions()),
-    audioSampleRate(FIXED_AUDIO_SAMPLE_RATE),
-    audioFormat("S16_LE"),
-    audioChannels(1)
+    udev_fd(-1)
 {
     console = spdlog::stdout_color_mt("cinepi_sound");
     console->set_level(spdlog::level::debug);  // or trace if you want even more
@@ -249,7 +255,7 @@ bool CinePISound::recording_ended() {
 }
 
 bool CinePISound::isRecording() {
-    return (recording_ && (ts_first_buffer_b > 0) || !canRecordAudio);
+    return (recording_ && ts_first_buffer_b > 0) || !canRecordAudio;
 }
 
 void CinePISound::detectRecordingDevices() {
@@ -274,7 +280,6 @@ void CinePISound::detectRecordingDevices() {
         canRecordAudio = false;
     } else {
         size_t start = result.find("card ");
-        size_t end = result.find(":", start);
         defaultDevice = "hw:" + result.substr(start + 5, 1) + ",0";
         canRecordAudio = true;
     }
@@ -323,8 +328,6 @@ void CinePISound::soundThread() {
 
             if (!std::filesystem::exists(filename)) break;
 
-            double audio_duration = samples_captured / static_cast<double>(audioSampleRate);
-
             int64_t vts_start = 0, vts_end = 0;
             int64_t frames = app_->GetEncoder()->timestamps.size();
             if (frames > 0) {
@@ -333,7 +336,7 @@ void CinePISound::soundThread() {
             }
 
             double vts_delta = (vts_end - vts_start) / 1e9;
-            if (vts_start < ts_first_buffer_b) {
+            if (vts_start < static_cast<int64_t>(ts_first_buffer_b)) {
                 console->critical("Frame start before audio!!!!");
                 return;
             }

--- a/cinepi/dng_encoder.cpp
+++ b/cinepi/dng_encoder.cpp
@@ -110,7 +110,7 @@ static const std::map<PixelFormat, BayerFormat> bayer_formats =
 	{ formats::R10_CSI2P, { "BGGR-10", 10, CFA_BGGR, true, false } },
 	{ formats::R10, { "BGGR-10", 10, CFA_BGGR, false, false } },
 	// Currently not in the main libcamera branch
-	{ formats::R12_CSI2P, { "BGGR-12", 12, CFA_BGGR, true } },
+        { formats::R12_CSI2P, { "BGGR-12", 12, CFA_BGGR, true, false } },
 	{ formats::R12, { "BGGR-12", 12, CFA_BGGR, false, false } },
     { formats::R16, { "BGGR-16", 16, CFA_BGGR, false, false } },
 

--- a/core/options.hpp
+++ b/core/options.hpp
@@ -94,11 +94,11 @@ struct TimeVal
 
 struct Options
 {
-	Options()
-	: hdmi_port(-1),                    /* ‑1 = let DRM decide   */
-		set_default_lens_position(false), af_on_capture(false),
-		keep16(false),                           // ← NEW default
-		options_("Valid options are", 120, 80), app_(nullptr)
+        Options()
+        : set_default_lens_position(false), af_on_capture(false),
+                hdmi_port(-1),                    /* ‑1 = let DRM decide   */
+                keep16(false),                           // ← NEW default
+                options_("Valid options are", 120, 80), app_(nullptr)
 	{
 		using namespace boost::program_options;
 		// clang-format off


### PR DESCRIPTION
## Summary
- reorder constructor initializer lists to match member declarations
- clean up CinePISound logic to remove unused variables and clarify checks
- add missing initializer for Bayer format to silence compiler warnings

## Testing
- `ninja -C build` *(fails: build directory missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f93c0a0c448332838280c4e590d13a