### PR TITLE
Fix scaler crops logging placeholder mismatch

### DIFF
--- a/cinepi/cinepi_options.cpp
+++ b/cinepi/cinepi_options.cpp
@@ -383,8 +383,7 @@ bool CinePiOptions::Parse(int argc, char *argv[])
         RawOptions::camPort = camPort;
 
         /* Log summary ------------------------------------------------- */
-        spdlog::info("cinepi-cli: camPort='{}'  hdmi_port={}  same_hdmi={}  zoom={}  crops={}"
-                     "crops={} rectangles",
+        spdlog::info("cinepi-cli: camPort='{}'  hdmi_port={}  same_hdmi={}  zoom={}  crops={} rectangles",
                      camPort,
                      hdmi_port,
                      same_hdmi ? "true" : "false",


### PR DESCRIPTION
## Summary
- consolidate the cinepi-cli crops summary log message into a single format string
- ensure the logged placeholder count matches the argument list

## Testing
- ⚠️ `./cinepi-raw --mode 3856:2180:16:U --hdr sensor` *(fails: binary not built in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f9569210b88332b7d1a9177c34ce2f