### PR TITLE
Improve audio hardware probing fallback

### DIFF
--- a/cinepi/cinepi_sound.cpp
+++ b/cinepi/cinepi_sound.cpp
@@ -4,6 +4,7 @@
 #include <boost/rational.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 #include <fstream>
+#include <regex>
 #include <sys/wait.h>
 
 constexpr int FIXED_AUDIO_SAMPLE_RATE = 48000;
@@ -342,6 +343,34 @@ void CinePISound::detectRecordingDevices() {
     console->debug("Audio device present: {}", canRecordAudio ? "yes" : "no");
 }
 
+std::vector<std::string> CinePISound::parseArecordAliases() {
+    std::vector<std::string> aliases;
+    FILE* fp = popen("arecord -l 2>/dev/null", "r");
+    if (!fp) {
+        console->warn("parseArecordAliases(): failed to run arecord -l");
+        return aliases;
+    }
+
+    std::regex re(R"(card\s+(\d+):.*device\s+(\d+):)");
+    char buf[512];
+    while (fgets(buf, sizeof(buf), fp)) {
+        std::cmatch match;
+        if (std::regex_search(buf, match, re)) {
+            std::string card = match[1];
+            std::string device = match[2];
+            aliases.push_back("plughw:" + card + "," + device);
+            aliases.push_back("hw:" + card + "," + device);
+        }
+    }
+    pclose(fp);
+
+    std::sort(aliases.begin(), aliases.end());
+    aliases.erase(std::unique(aliases.begin(), aliases.end()), aliases.end());
+
+    console->debug("parseArecordAliases(): discovered {} aliases", aliases.size());
+    return aliases;
+}
+
 void CinePISound::soundThread() {
     init_udev();
 
@@ -521,6 +550,11 @@ std::string CinePISound::getPreferredMonitorOutput() {
 void CinePISound::parseHardwareParams() {
     audioSampleRate = FIXED_AUDIO_SAMPLE_RATE;
 
+    audioFormat.clear();
+    defaultDevice.clear();
+    audioChannels  = 0;
+    canRecordAudio = false;
+
     if (tryAudioConfig("mic_24bit", "S24_3LE", 2, audioSampleRate)) {
         audioFormat    = "S24_3LE";
         audioChannels  = 2;
@@ -534,11 +568,24 @@ void CinePISound::parseHardwareParams() {
         canRecordAudio = true;
         console->info("parseHardwareParams(): using mic_16bit");
     } else {
-        audioFormat.clear();
-        defaultDevice.clear();
-        audioChannels   = 0;
-        canRecordAudio  = false;
-        console->error("parseHardwareParams(): no usable mic_* alias found");
+        auto aliases = parseArecordAliases();
+        for (const auto& alias : aliases) {
+            for (int channels : {1, 2}) {
+                if (tryAudioConfig(alias, "S16_LE", channels, audioSampleRate)) {
+                    audioFormat    = "S16_LE";
+                    audioChannels  = channels;
+                    defaultDevice  = alias;
+                    canRecordAudio = true;
+                    console->info("parseHardwareParams(): using fallback alias {} ({} ch)",
+                                  alias, channels);
+                    break;
+                }
+            }
+            if (canRecordAudio) break;
+        }
+        if (!canRecordAudio) {
+            console->error("parseHardwareParams(): no usable audio devices after probing aliases");
+        }
     }
 
     if (canRecordAudio) {

--- a/cinepi/cinepi_sound.hpp
+++ b/cinepi/cinepi_sound.hpp
@@ -1,15 +1,17 @@
 #pragma once
 
-#include <iostream>
-#include <cstdio>
-#include <cstdlib>
-#include <csignal>
-#include <sstream>
+#include <array>
 #include <chrono>
-#include <sys/wait.h>
+#include <cstdio>
+#include <csignal>
+#include <cstdlib>
 #include <filesystem>
+#include <iostream>
 #include <regex>
+#include <sstream>
+#include <sys/wait.h>
 #include <unistd.h>
+#include <vector>
 
 #include <thread>
 #include <pthread.h>
@@ -51,6 +53,7 @@ private:
     bool recording_ended();
     void generateXML(std::string fn);
     void publishMicSelection();
+    std::vector<std::string> parseArecordAliases();
 
 
 


### PR DESCRIPTION
## Summary
- add parsing of `arecord -l` output to discover fallback aliases for audio probing
- reset audio hardware state before probing and log probe results similar to Cinemate
- try discovered aliases with 16-bit mono and stereo configurations before disabling recording

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f78c3f8488332bca731163b026072)