### PR TITLE
Ensure WAV recording drains arecord pipe

### DIFF
--- a/cinepi/cinepi_sound.cpp
+++ b/cinepi/cinepi_sound.cpp
@@ -427,7 +427,10 @@ void CinePISound::soundThread() {
     init_udev();
 
     while (!abortThread_) {
-        if (record_ && (pid > 0)) {
+        // Always drain the arecord pipe until the child exits, even after record_stop()
+        // clears the record_ flag. Otherwise the pipe would never be closed and the WAV
+        // file would remain incomplete/unwritten, resulting in 0 WAV clips.
+        if (pid > 0) {
             char buffer[256];
             std::string result = "";
             while (fgets(buffer, sizeof(buffer), arec_pipe) != NULL) {


### PR DESCRIPTION
## Summary
- keep draining the arecord pipe after stop to ensure it closes cleanly
- avoid leaving WAV files unwritten when audio recording is terminated

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f868f7da883328f179f143d5e67b6)