### PR TITLE
Improve USB mic compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ nano ~/.asoundrc
 
 ```bash
 
+    # Replace "Device" with the stable card name from `arecord -l`
+    # If your microphone is mono-only, set channels to 1 and use S16_LE
     pcm.dsnoop_24bit {
         type dsnoop
         ipc_key 2048
@@ -202,6 +204,9 @@ nano ~/.asoundrc
         type plug
         slave.pcm "dsnoop_16bit"
     }
+
+- Make sure the `pcm "hw:Device,0"` line matches your actual card name (e.g., "hw:USB", "hw:NTG").
+- Set `channels`/`format` to what the mic supports; a mono 16‑bit mic should use the `dsnoop_16bit` values, otherwise `arecord` will fail and no WAV is produced.
 
 ```
 

--- a/cinepi/cinepi_sound.cpp
+++ b/cinepi/cinepi_sound.cpp
@@ -242,6 +242,8 @@ bool CinePISound::tryAudioConfig(const std::string& device, const std::string& f
         return true;
     } else {
         console->debug("Probe FAILED rc={} : {} | {}", exit_code, cmd.str(), stderr_one);
+        console->warn("Audio probe failed for {} (fmt {}, ch {}, {} Hz): {}", device, format, channels, rate,
+                     stderr_one.empty() ? "no error output" : stderr_one);
         return false;
     }
 }
@@ -276,7 +278,6 @@ void CinePISound::record_start() {
               << " -c " << audioChannels
               << " -r " << audioSampleRate
               << " -t wav"
-              << " --disable-resample"
               << " --disable-softvol"
               << " -V " << vu_mode
               << " " << filename << " 2>&1";
@@ -427,7 +428,10 @@ void CinePISound::soundThread() {
     init_udev();
 
     while (!abortThread_) {
-        if (record_ && (pid > 0)) {
+        // Always drain the arecord pipe until the child exits, even after record_stop()
+        // clears the record_ flag. Otherwise the pipe would never be closed and the WAV
+        // file would remain incomplete/unwritten, resulting in 0 WAV clips.
+        if (pid > 0) {
             char buffer[256];
             std::string result = "";
             while (fgets(buffer, sizeof(buffer), arec_pipe) != NULL) {


### PR DESCRIPTION
## Summary
- allow arecord to resample when the microphone cannot natively deliver 48 kHz, improving compatibility with consumer USB mics
- surface the first arecord error line when probing audio devices to aid diagnosing missing/incorrect ALSA configs
- document that the .asoundrc card name/format must match the actual microphone capabilities

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f868f7da883328f179f143d5e67b6)