### PR TITLE
Silence alsaloop underrun spam in audio monitor

### DIFF
--- a/cinepi/cinepi_sound.cpp
+++ b/cinepi/cinepi_sound.cpp
@@ -494,7 +494,7 @@ void CinePISound::parseHardwareParams() {
             std::ostringstream mon_cmd;
             mon_cmd << "alsaloop -C " << defaultDevice
                     << " -P " << outputDevice
-                    << " -t 10000 -A 1 -d";
+                    << " -t 10000 -A 1 -d 2>/dev/null";
     
             console->info("Starting audio monitoring: {}", mon_cmd.str());
             monitor_pipe = popen2(mon_cmd.str(), "r", monitor_pid);


### PR DESCRIPTION
### Motivation
- Prevent `alsaloop` underrun messages from flooding system logs while keeping the audio monitoring process active.

### Description
- Redirect `alsaloop` stderr to `/dev/null` by appending `2>/dev/null` to the command constructed in `cinepi/cinepi_sound.cpp` when starting the monitor (the call that is passed to `popen2`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69863f6ac5d88332815cf3dacac8220e)