### PR TITLE
Silence alsaloop underrun spam in monitor loop

### DIFF
--- a/cinepi/cinepi_sound.cpp
+++ b/cinepi/cinepi_sound.cpp
@@ -375,7 +375,8 @@ void CinePISound::startMonitoring() {
     std::ostringstream mon_cmd;
     mon_cmd << "alsaloop -C " << defaultDevice
             << " -P " << outputDevice
-            << " -t 10000 -A 1 -d";
+            << " -t 10000 -A 1 -d"
+            << " 2>/dev/null";
     console->info("Starting audio monitoring: {}", mon_cmd.str());
     monitor_pipe = popen2(mon_cmd.str(), "r", monitor_pid);
     if (monitor_pid > 0 && monitor_pipe) {


### PR DESCRIPTION
### Motivation
- Stop repetitive `alsaloop` underrun messages flooding the `cinemate-autostart` service logs by suppressing the tool's stderr output.

### Description
- In `CinePISound::startMonitoring()` append `2>/dev/null` to the `alsaloop` command invocation in `cinepi/cinepi_sound.cpp` so `alsaloop` stderr is discarded.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698640922f308332b4fbd781814760bc)