### PR TITLE
Add low-overhead cp_stats observability and per-frame log throttling

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ The following flags extend the base `rpicam-apps` functionality with CinePi-rawâ
 | `--disk-affinity <list>`  | `auto`  | Pin disk workers to the specified CPU list. |
 | `--encode-nice <int>`     | `auto`  | Nice level for encode workers (`-20` = highest priority, `19` = lowest). |
 | `--disk-nice <int>`       | `auto`  | Nice level applied to disk workers. |
+| `--latency-sample-interval <n>` | `10` | Sample encode/disk latency metrics every N frames for `cp_stats`. |
+| `--per-frame-logs[=bool]` | `false` | Enable verbose per-frame encoder/disk DEBUG logs (`true/false`, `1/0`). |
 
 ## Manual DNG encoder
 
@@ -236,3 +238,13 @@ SET zoom 1.5
 PUBLISH cp_controls zoom
 ```
 CinemaDNGs always contain the entire sensor.
+
+### cp_stats observability fields
+
+`cp_stats` now publishes additional fields for Cinemate v2/analyzer compatibility while preserving existing keys:
+
+- Per-frame fields: `sensorTimestamp`, `stats_seq`, `encode_queue_size`, `disk_queue_size`, `ram_buffers`.
+- Sampled fields: `encode_latency_ms`, `disk_latency_ms` (sampled every `--latency-sample-interval` frames, default `10`).
+- Sampling behavior: sampled latency keys are repeated with the last sampled value until the next sample refresh.
+
+High-frequency per-frame encode/disk logs are now DEBUG-gated and disabled by default; startup/configuration logs remain INFO/WARN/ERROR.

--- a/cinepi/cinepi_controller.cpp
+++ b/cinepi/cinepi_controller.cpp
@@ -255,12 +255,27 @@ void CinePIController::process(CompletedRequestPtr &completed_request)
     /*  2. Publish live stats                                        */
     /* ────────────────────────────────────────────────────────────── */
     Json::Value data;
-    data["framerate"]  = completed_request->framerate;
-    data["colorTemp"]  = info.colorTemp;
-    data["focus"]      = info.focus;
-    data["frameCount"] = app_->GetEncoder()->getFrameCount();
-    data["bufferSize"] = app_->GetEncoder()->bufferSize();
-    data["timestamp"]  = static_cast<Json::Int64>(epoch_ns);   // ← TOD ns
+    const uint64_t stats_seq = stats_seq_.fetch_add(1, std::memory_order_relaxed) + 1;
+    auto *encoder = app_->GetEncoder();
+
+    data["framerate"]         = completed_request->framerate;
+    data["colorTemp"]         = info.colorTemp;
+    data["focus"]             = info.focus;
+    data["frameCount"]        = encoder->getFrameCount();
+    data["bufferSize"]        = encoder->bufferSize();
+    data["timestamp"]         = static_cast<Json::Int64>(epoch_ns);   // wall-clock ns
+    data["sensorTimestamp"]   = static_cast<Json::Int64>(info.ts);     // sensor monotonic ns
+    data["stats_seq"]         = static_cast<Json::UInt64>(stats_seq);
+    data["encode_queue_size"] = static_cast<Json::UInt64>(encoder->encodeQueueSize());
+    data["disk_queue_size"]   = static_cast<Json::UInt64>(encoder->diskQueueSize());
+    data["ram_buffers"]       = static_cast<Json::UInt64>(encoder->ramBuffers());
+
+    // Latencies are sampled every N frames in the encoder and repeated until refreshed.
+    if (auto encode_latency = encoder->sampledEncodeLatencyMs(); encode_latency)
+        data["encode_latency_ms"] = static_cast<Json::UInt>(*encode_latency);
+    if (auto disk_latency = encoder->sampledDiskLatencyMs(); disk_latency)
+        data["disk_latency_ms"] = static_cast<Json::UInt>(*disk_latency);
+
     redis_->publish(CHANNEL_STATS, data.toStyledString());
 
     /* cache per-camera timestamp key (TOD ns) */

--- a/cinepi/cinepi_controller.hpp
+++ b/cinepi/cinepi_controller.hpp
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <thread>
 #include <chrono>
+#include <atomic>
 
 //external dependancies
 #include <sw/redis++/redis++.h>
@@ -237,6 +238,8 @@ class CinePIController : public CinePIState
         std::unique_ptr<sw::redis::Redis> redis_;
 
         Json::Value allData;
+
+        std::atomic<uint64_t> stats_seq_{0};
 
         bool abortThread_;
         std::thread main_thread_;

--- a/cinepi/cinepi_options.cpp
+++ b/cinepi/cinepi_options.cpp
@@ -208,7 +208,13 @@ CinePiOptions::CinePiOptions()
                     "Nice level (-20..19) for encode workers")
                 ("disk-nice",
                     value<int>(),
-                    "Nice level (-20..19) for disk workers");
+                    "Nice level (-20..19) for disk workers")
+                ("latency-sample-interval",
+                    value<unsigned int>()->default_value(10),
+                    "Publish encode/disk latency stats every N frames")
+                ("per-frame-logs",
+                    value<bool>()->default_value(false)->implicit_value(true),
+                    "Enable verbose per-frame encode/disk logging (default: off)");
         options_.add(cinepi_group);
 }
 
@@ -232,6 +238,19 @@ static std::string trimToken(const std::string &token)
                 return "";
         const auto end = token.find_last_not_of(" \t");
         return token.substr(start, end - start + 1);
+}
+
+static bool parseBoolString(const std::string &flag, std::string value)
+{
+        std::transform(value.begin(), value.end(), value.begin(),
+                       [](unsigned char ch) { return std::tolower(ch); });
+
+        if (value == "1" || value == "true" || value == "yes" || value == "on")
+                return true;
+        if (value == "0" || value == "false" || value == "no" || value == "off")
+                return false;
+
+        throw std::runtime_error(flag + " expects true/false (or 1/0), got: " + value);
 }
 
 static unsigned int parseWorkerCount(const std::string &flag, const std::string &value)
@@ -481,6 +500,29 @@ bool CinePiOptions::Parse(int argc, char *argv[])
                         continue;
                 }
 
+                if (arg.rfind("--latency-sample-interval=", 0) == 0) {
+                        RawOptions::latency_sample_interval = parseWorkerCount("--latency-sample-interval", arg.substr(sizeof("--latency-sample-interval=") - 1));
+                        continue;
+                }
+                if (arg == "--latency-sample-interval") {
+                        if (i + 1 >= argc)
+                                throw std::runtime_error("--latency-sample-interval requires a value");
+                        RawOptions::latency_sample_interval = parseWorkerCount("--latency-sample-interval", argv[++i]);
+                        continue;
+                }
+
+                if (arg.rfind("--per-frame-logs=", 0) == 0) {
+                        RawOptions::per_frame_logs = parseBoolString("--per-frame-logs", arg.substr(sizeof("--per-frame-logs=") - 1));
+                        continue;
+                }
+                if (arg == "--per-frame-logs") {
+                        if (i + 1 < argc && argv[i + 1][0] != '-')
+                                RawOptions::per_frame_logs = parseBoolString("--per-frame-logs", argv[++i]);
+                        else
+                                RawOptions::per_frame_logs = true;
+                        continue;
+                }
+
                 /* not a CinePi flag – forward it */
                 forward.push_back(argv[i]);
         }
@@ -542,13 +584,15 @@ bool CinePiOptions::Parse(int argc, char *argv[])
                      Zoom(),
                      scaler_crops_rects.size());
 
-        spdlog::info("cinepi-cli: encode_workers={} disk_workers={} encode_affinity={} disk_affinity={} encode_nice={} disk_nice={}",
+        spdlog::info("cinepi-cli: encode_workers={} disk_workers={} encode_affinity={} disk_affinity={} encode_nice={} disk_nice={} latency_sample_interval={} per_frame_logs={}",
                       RawOptions::encode_workers,
                       RawOptions::disk_workers,
                       cpuListToString(RawOptions::encode_affinity),
                       cpuListToString(RawOptions::disk_affinity),
                       RawOptions::encode_nice ? std::to_string(*RawOptions::encode_nice) : std::string("auto"),
-                      RawOptions::disk_nice ? std::to_string(*RawOptions::disk_nice) : std::string("auto"));
+                      RawOptions::disk_nice ? std::to_string(*RawOptions::disk_nice) : std::string("auto"),
+                      RawOptions::latency_sample_interval,
+                      RawOptions::per_frame_logs ? "true" : "false");
 
         return ok;
 }

--- a/cinepi/dng_encoder.cpp
+++ b/cinepi/dng_encoder.cpp
@@ -125,6 +125,18 @@ static const std::map<PixelFormat,int> mono_formats = {
 
 bool mono_ = false;   // add as a private member of DngEncoder
 
+static inline void decrementIfPositive(std::atomic<size_t> &counter)
+{
+    size_t current = counter.load(std::memory_order_relaxed);
+    while (current > 0 &&
+           !counter.compare_exchange_weak(current,
+                                          current - 1,
+                                          std::memory_order_relaxed,
+                                          std::memory_order_relaxed))
+    {
+    }
+}
+
 void DngEncoder::setWallClockTimestamp(uint64_t us)
 {
     wallclock_ts_us_ = us;
@@ -362,6 +374,15 @@ void DngEncoder::stopThreads()
 
     encode_threads_.clear();
     disk_threads_.clear();
+
+    {
+        std::lock_guard<std::mutex> lock(encode_mutex_);
+        encode_queue_size_.store(encode_queue_.size(), std::memory_order_relaxed);
+    }
+    {
+        std::lock_guard<std::mutex> lock(disk_mutex_);
+        disk_queue_size_.store(disk_buffer_.size(), std::memory_order_relaxed);
+    }
 }
 
 void DngEncoder::configureThreadContext(const std::string &baseName,
@@ -878,7 +899,7 @@ void DngEncoder::encodeThread(int num)
 
             encode_item = encode_queue_.front();
             encode_queue_.pop();
-            encode_queue_size_.fetch_sub(1, std::memory_order_relaxed);
+            decrementIfPositive(encode_queue_size_);
         }
 
         frames_ = encode_item.index;
@@ -999,7 +1020,7 @@ void DngEncoder::diskThread(int num)
 
             disk_item = disk_buffer_.front();
             disk_buffer_.pop();
-            disk_queue_size_.fetch_sub(1, std::memory_order_relaxed);
+            decrementIfPositive(disk_queue_size_);
         }
 
         std::ostringstream oss;
@@ -1075,8 +1096,9 @@ void DngEncoder::clearPool()
                 if (ram_buffers_ > 0) --ram_buffers_;
             }
             disk_buffer_.pop();
-            disk_queue_size_.fetch_sub(1, std::memory_order_relaxed);
+            decrementIfPositive(disk_queue_size_);
         }
+        disk_queue_size_.store(disk_buffer_.size(), std::memory_order_relaxed);
         ram_cv_.notify_all();
     }
 }

--- a/cinepi/dng_encoder.cpp
+++ b/cinepi/dng_encoder.cpp
@@ -130,6 +130,22 @@ void DngEncoder::setWallClockTimestamp(uint64_t us)
     wallclock_ts_us_ = us;
 }
 
+std::optional<uint32_t> DngEncoder::sampledEncodeLatencyMs() const
+{
+    if (!has_sampled_encode_latency_.load(std::memory_order_acquire))
+        return std::nullopt;
+
+    return sampled_encode_latency_ms_.load(std::memory_order_relaxed);
+}
+
+std::optional<uint32_t> DngEncoder::sampledDiskLatencyMs() const
+{
+    if (!has_sampled_disk_latency_.load(std::memory_order_acquire))
+        return std::nullopt;
+
+    return sampled_disk_latency_ms_.load(std::memory_order_relaxed);
+}
+
 void pack_8bit_data(const uint16_t* src, uint8_t* dst, size_t num_pixels) {
     for (size_t i = 0; i < num_pixels; i++) {
         dst[0] = src[i];
@@ -284,6 +300,9 @@ DngEncoder::DngEncoder(RawOptions const *options)
     if (!console)
         console = spdlog::stdout_color_mt("dng_encoder");
 
+    if (options_ && options_->per_frame_logs)
+        console->set_level(spdlog::level::debug);
+
     if (options_)
     {
         encode_worker_count_ = std::max<uint32_t>(1, options_->encode_workers);
@@ -292,6 +311,7 @@ DngEncoder::DngEncoder(RawOptions const *options)
         disk_affinity_       = options_->disk_affinity;
         encode_nice_         = options_->encode_nice;
         disk_nice_           = options_->disk_nice;
+        latency_sample_interval_ = std::max<uint32_t>(1, options_->latency_sample_interval);
     }
     else
     {
@@ -430,6 +450,7 @@ void DngEncoder::EncodeBuffer2(int fd, size_t size, void *mem, StreamInfo const 
         std::lock_guard<std::mutex> lock(encode_mutex_);
         EncodeItem item = { mem, size, info, lomem, losize, loinfo, metadata, timestamp_us, index_++ };
         encode_queue_.push(item);
+        encode_queue_size_.fetch_add(1, std::memory_order_relaxed);
         encode_cond_var_.notify_one();
     }
 }
@@ -857,6 +878,7 @@ void DngEncoder::encodeThread(int num)
 
             encode_item = encode_queue_.front();
             encode_queue_.pop();
+            encode_queue_size_.fetch_sub(1, std::memory_order_relaxed);
         }
 
         frames_ = encode_item.index;
@@ -924,13 +946,29 @@ void DngEncoder::encodeThread(int num)
 
             std::lock_guard<std::mutex> lock(disk_mutex_);
             disk_buffer_.push(std::move(item));
+            disk_queue_size_.fetch_add(1, std::memory_order_relaxed);
             disk_cond_var_.notify_one();
         }
 
         auto end_time = std::chrono::high_resolution_clock::now();
-        auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count();
-        console->info("Thread[{}] {} Time taken for the encode: {} ms, disk queue:{}  Size:{}",
-                      num, encode_item.index, duration, disk_buffer_.size(), tiff_size);
+        const auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count();
+
+        const bool sample_latency = ((encode_item.index % latency_sample_interval_) == 0);
+        if (sample_latency)
+        {
+            sampled_encode_latency_ms_.store(static_cast<uint32_t>(duration), std::memory_order_relaxed);
+            has_sampled_encode_latency_.store(true, std::memory_order_release);
+        }
+
+        if (options_ && options_->per_frame_logs && console->should_log(spdlog::level::debug))
+        {
+            console->debug("Thread[{}] {} encode={} ms, disk queue:{} size:{}",
+                           num,
+                           encode_item.index,
+                           duration,
+                           disk_queue_size_.load(std::memory_order_relaxed),
+                           tiff_size);
+        }
 
         /* mark the camera buffer as reusable */
         input_done_callback_(nullptr);
@@ -961,6 +999,7 @@ void DngEncoder::diskThread(int num)
 
             disk_item = disk_buffer_.front();
             disk_buffer_.pop();
+            disk_queue_size_.fetch_sub(1, std::memory_order_relaxed);
         }
 
         std::ostringstream oss;
@@ -974,7 +1013,8 @@ void DngEncoder::diskThread(int num)
     
         console->trace("Thread[{}]  Save frame to disk: {}", num, disk_item.index);
 
-        console->info("DNG written: {}", filename);
+        if (options_ && options_->per_frame_logs && console->should_log(spdlog::level::debug))
+            console->debug("DNG written: {}", filename);
         
         auto start_time = std::chrono::high_resolution_clock::now();
         
@@ -1007,8 +1047,17 @@ void DngEncoder::diskThread(int num)
         }
 
         auto end_time = std::chrono::high_resolution_clock::now();
-        auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count();
-        console->info("Thread[{}] {} Time taken for the disk io: {} milliseconds", num, disk_item.index, duration);
+        const auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count();
+
+        const bool sample_latency = ((disk_item.index % latency_sample_interval_) == 0);
+        if (sample_latency)
+        {
+            sampled_disk_latency_ms_.store(static_cast<uint32_t>(duration), std::memory_order_relaxed);
+            has_sampled_disk_latency_.store(true, std::memory_order_release);
+        }
+
+        if (options_ && options_->per_frame_logs && console->should_log(spdlog::level::debug))
+            console->debug("Thread[{}] {} disk io={} ms", num, disk_item.index, duration);
     }
 }
 
@@ -1026,6 +1075,7 @@ void DngEncoder::clearPool()
                 if (ram_buffers_ > 0) --ram_buffers_;
             }
             disk_buffer_.pop();
+            disk_queue_size_.fetch_sub(1, std::memory_order_relaxed);
         }
         ram_cv_.notify_all();
     }

--- a/cinepi/dng_encoder.hpp
+++ b/cinepi/dng_encoder.hpp
@@ -52,11 +52,17 @@ public:
 		uint64_t fn);
 
 	int bufferSize(){
-		return disk_buffer_.size();
+		return static_cast<int>(disk_queue_size_.load(std::memory_order_relaxed));
 	}
 	uint64_t getFrameCount(){
 		return frames_;
 	}
+
+	size_t encodeQueueSize() const { return encode_queue_size_.load(std::memory_order_relaxed); }
+	size_t diskQueueSize() const { return disk_queue_size_.load(std::memory_order_relaxed); }
+	size_t ramBuffers() const { return ram_buffers_.load(std::memory_order_relaxed); }
+	std::optional<uint32_t> sampledEncodeLatencyMs() const;
+	std::optional<uint32_t> sampledDiskLatencyMs() const;
 
 	uint16_t photometric;
 	uint16_t samples_per_pixel;
@@ -98,6 +104,13 @@ private:
 
     /* ──  NEW: in-RAM buffer accounting  ─────────────────────── */
     std::atomic<size_t>   ram_buffers_{0};   /* # TIFF blocks living in RAM   */
+    std::atomic<size_t>   encode_queue_size_{0};
+    std::atomic<size_t>   disk_queue_size_{0};
+    std::atomic<uint32_t> sampled_encode_latency_ms_{0};
+    std::atomic<uint32_t> sampled_disk_latency_ms_{0};
+    std::atomic<bool>     has_sampled_encode_latency_{false};
+    std::atomic<bool>     has_sampled_disk_latency_{false};
+    uint32_t              latency_sample_interval_{10};
     size_t                max_ram_buffers_;  /* hard cap calculated at setup  */
     std::mutex            ram_mtx_;
     std::condition_variable ram_cv_;

--- a/cinepi/dng_encoder.hpp
+++ b/cinepi/dng_encoder.hpp
@@ -52,7 +52,8 @@ public:
 		uint64_t fn);
 
 	int bufferSize(){
-		return static_cast<int>(disk_queue_size_.load(std::memory_order_relaxed));
+		std::lock_guard<std::mutex> lock(disk_mutex_);
+		return static_cast<int>(disk_buffer_.size());
 	}
 	uint64_t getFrameCount(){
 		return frames_;

--- a/cinepi/raw_options.hpp
+++ b/cinepi/raw_options.hpp
@@ -61,4 +61,8 @@ struct RawOptions : public VideoOptions
     std::optional<std::vector<int>> disk_affinity;
     std::optional<int> encode_nice;
     std::optional<int> disk_nice;
+
+    /* observability / logging tuning */
+    uint32_t latency_sample_interval { 10 };
+    bool per_frame_logs { false };
 };


### PR DESCRIPTION
### Motivation

- Cinemate v2 expects additional explicit `cp_stats` fields and frequent INFO logs were perturbing runtime and flooding relay paths. 
- We need low-overhead, lock-minimal metrics (queue sizes, sampled latencies, monotonic timestamps/seq) while preserving existing behavior and Redis keys. 
- Sampling latency rather than publishing full per-frame latencies reduces hot-path work and relay traffic. 

### Description

- Publish new `cp_stats` fields from `CinePIController::process`: `sensorTimestamp`, `stats_seq`, `encode_queue_size`, `disk_queue_size`, `ram_buffers`, and sampled `encode_latency_ms` / `disk_latency_ms` (latency values are sampled in the encoder and repeated until refreshed). Files changed: `cinepi/cinepi_controller.cpp` and `cinepi/cinepi_controller.hpp`. 
- Add low-overhead encoder-side observability in `DngEncoder`: atomic `encode_queue_size_`, `disk_queue_size_`, `ram_buffers_` accessors, atomic sampled latency snapshots and `sampled*()` accessors; update enqueue/dequeue paths to update atomics without locking. Files changed: `cinepi/dng_encoder.cpp` and `cinepi/dng_encoder.hpp`. 
- Reduce high-frequency INFO logging by demoting per-frame encode/disk timing and "DNG written" messages to DEBUG and gating them behind a runtime flag, while keeping startup/config logs at INFO; add `--per-frame-logs` to enable verbose per-frame DEBUG logs. Files changed: `cinepi/dng_encoder.cpp`, `cinepi/cinepi_options.cpp`, `cinepi/raw_options.hpp`. 
- Add CLI/runtime knobs: `--latency-sample-interval <n>` (default `10`) and `--per-frame-logs[=bool]` (default `false`), parse them in `cinepi/cinepi_options.cpp`, expose defaults in `README.md`, and document cp_stats fields and sampling behavior. Files changed: `cinepi/cinepi_options.cpp`, `cinepi/raw_options.hpp`, `README.md`.

### Testing

- Ran `git diff --check` to verify no whitespace/patch issues, which passed. 
- Verified repository status with `git status --short` and committed the changes successfully. 
- Attempted build with `meson setup && meson compile -C build` but the build could not be executed in this environment because `meson` is not installed, so a full compile/runtime 60s 4K validation was not run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad7858affc8332b4c2c63befda339a)