### PR TITLE
Reduce CPU/jitter in cinepi-raw: single-worker defaults, DNG tag caching, and disk-path optimizations

### DIFF
--- a/cinepi/cinepi_raw.cpp
+++ b/cinepi/cinepi_raw.cpp
@@ -183,7 +183,8 @@ static void event_loop(CinePIRecorder &app, CinePIController &controller, CinePI
 
 
 		// show frame on display
-		app.ShowPreview(completed_request, app.LoresStream());//app.GetMainStream());
+		if (!options->nopreview)
+			app.ShowPreview(completed_request, app.LoresStream());//app.GetMainStream());
 
 		//console->info("Frame Number: {}", count);
 	}
@@ -209,6 +210,13 @@ int main(int argc, char *argv[])
 
 			if (options->verbose >= 2)
 				options->Print();
+
+			spdlog::info("cinepi-runtime: nopreview={} encode_workers={} disk_workers={} latency_sample_interval={} per_frame_logs={}",
+				            options->nopreview ? "true" : "false",
+				            options->encode_workers,
+				            options->disk_workers,
+				            options->latency_sample_interval,
+				            options->per_frame_logs ? "true" : "false");
 
 			event_loop(app, controller, sound);
 		}

--- a/cinepi/dng_encoder.cpp
+++ b/cinepi/dng_encoder.cpp
@@ -12,6 +12,7 @@
  #include <libcamera/control_ids.h> // metadata.get(controls::...)
  #include <libcamera/formats.h>     // libcamera::formats::
  #include <cstring>
+ #include <cstdio>
  #include <stdexcept>
  #include <iomanip>
  
@@ -124,6 +125,21 @@ static const std::map<PixelFormat,int> mono_formats = {
 
 
 bool mono_ = false;   // add as a private member of DngEncoder
+
+static std::string cpuListToString(const std::optional<std::vector<int>> &cpus)
+{
+    if (!cpus || cpus->empty())
+        return "auto";
+
+    std::ostringstream oss;
+    for (size_t i = 0; i < cpus->size(); ++i)
+    {
+        if (i)
+            oss << ',';
+        oss << (*cpus)[i];
+    }
+    return oss.str();
+}
 
 static inline void decrementIfPositive(std::atomic<size_t> &counter)
 {
@@ -327,8 +343,9 @@ DngEncoder::DngEncoder(RawOptions const *options)
     }
     else
     {
-        encode_worker_count_ = 2;
-        disk_worker_count_   = 8;
+        encode_worker_count_ = 1;
+        disk_worker_count_   = 1;
+        latency_sample_interval_ = 20;
     }
 
     encode_threads_.reserve(encode_worker_count_);
@@ -339,9 +356,15 @@ DngEncoder::DngEncoder(RawOptions const *options)
     for (size_t i = 0; i < disk_worker_count_; ++i)
         disk_threads_.emplace_back(&DngEncoder::diskThread, this, static_cast<int>(i));
 
-    console->info("DngEncoder started with {} encode worker(s) and {} disk worker(s)",
+    console->info("DngEncoder started: encode_workers={} disk_workers={} encode_affinity={} disk_affinity={} encode_nice={} disk_nice={} latency_sample_interval={} per_frame_logs={}",
                   encode_worker_count_,
-                  disk_worker_count_);
+                  disk_worker_count_,
+                  encode_affinity_ && !encode_affinity_->empty() ? cpuListToString(encode_affinity_) : std::string("auto"),
+                  disk_affinity_ && !disk_affinity_->empty() ? cpuListToString(disk_affinity_) : std::string("auto"),
+                  encode_nice_ ? std::to_string(*encode_nice_) : std::string("auto"),
+                  disk_nice_ ? std::to_string(*disk_nice_) : std::string("auto"),
+                  latency_sample_interval_,
+                  options_ && options_->per_frame_logs ? "true" : "false");
 }
 
 DngEncoder::~DngEncoder()
@@ -638,6 +661,10 @@ void DngEncoder::setup_encoder(const libcamera::StreamConfiguration &cfg,
                   max_ram_buffers_, (max_ram_buffers_ * dng_info.buffer_size) >> 20);
 
 
+    encode_rational_array(dng_info.CAM_XYZ, 9, static_tag_cache_.matrixXY);
+    encode_rational_array(dng_info.NEUTRAL, 3, static_tag_cache_.neutral);
+    static_tag_cache_.ready = true;
+
     encoder_initialized_ = true;
     console->info("Encoder configured – {}×{} {}-bit, buffer {} MB",
                   cfg.size.width, cfg.size.height,
@@ -733,20 +760,14 @@ size_t DngEncoder::dng_save([[maybe_unused]] int                /*thread_num*/,
     else
         std::fill(std::begin(black), std::end(black), 256);
 
-    /* ──  4.  Prepare matrices  ───────────────────────────────── */
-    int32_t matrixXY[18]; encode_rational_array(dng_info.CAM_XYZ, 9, matrixXY);
-    int32_t neutral[6];   encode_rational_array(dng_info.NEUTRAL, 3, neutral);
+    /* ──  4.  Prepare per-frame mutable tags only  ─────────────── */
+    thread_local int32_t blackRat[8];
 
     /* ──  5.  Build thumbnail IFD (SubIFD[0])  ───────────────── */
     IFDBuilder sub(dng_info.thumbWidth, dng_info.thumbHeight);
     sub.baseOffset = buf.usedSize;
 
-    uint32_t subType = 1;                 /* reduced-res */
-    uint16_t planar  = 1;
-    uint16_t sampFmt = SAMPLEFORMAT_UINT;
-    static const uint8_t v[4] = {1, 4, 0, 0};
-
-    sub.addEntry(254,  TIFF_LONG , 1, &subType);
+    sub.addEntry(254,  TIFF_LONG , 1, &static_tag_cache_.sub_type);
     sub.addEntry(256,  TIFF_SHORT, 1, &dng_info.thumbWidth);
     sub.addEntry(257,  TIFF_SHORT, 1, &dng_info.thumbHeight);
     sub.addEntry(258,  TIFF_SHORT, 1, &dng_info.thumbBitsPerSample);
@@ -756,10 +777,10 @@ size_t DngEncoder::dng_save([[maybe_unused]] int                /*thread_num*/,
     sub.addEntry(278,  TIFF_SHORT, 1, &dng_info.thumbHeight);
     sub.addEntry(279,  TIFF_LONG , 1, &thumbSize);
     sub.addEntry(277,  TIFF_SHORT, 1, &dng_info.thumbSamplesPerPixel);
-    sub.addEntry(284,  TIFF_SHORT, 1, &planar);
-    sub.addEntry(339,  TIFF_SHORT, 1, &sampFmt);
-    sub.addEntry(0xC612, TIFF_BYTE, 4, v);
-    sub.addEntry(0xC613, TIFF_BYTE, 4, v);
+    sub.addEntry(284,  TIFF_SHORT, 1, &static_tag_cache_.planar);
+    sub.addEntry(339,  TIFF_SHORT, 1, &static_tag_cache_.sample_format);
+    sub.addEntry(0xC612, TIFF_BYTE, 4, static_tag_cache_.dng_version);
+    sub.addEntry(0xC613, TIFF_BYTE, 4, static_tag_cache_.dng_version);
     sub.addEntry(0xC614, TIFF_ASCII, ucm_tag_.size(), ucm_tag_.data());
 
     sub.sortEntries(); sub.build(buf);
@@ -785,26 +806,24 @@ size_t DngEncoder::dng_save([[maybe_unused]] int                /*thread_num*/,
     ifd.addEntry(278 , TIFF_LONG , 1, &info.height);
     ifd.addEntry(279 , TIFF_LONG , 1, &rawSize);
     ifd.addEntry(277 , TIFF_SHORT, 1, &dng_info.samples_per_pixel);
-    ifd.addEntry(284 , TIFF_SHORT, 1, &planar);
-    ifd.addEntry(339 , TIFF_SHORT, 1, &sampFmt);
+    ifd.addEntry(284 , TIFF_SHORT, 1, &static_tag_cache_.planar);
+    ifd.addEntry(339 , TIFF_SHORT, 1, &static_tag_cache_.sample_format);
     ifd.addEntry(0x014A, TIFF_LONG, 1, &subIFDoff);
-    ifd.addEntry(0xC612, TIFF_BYTE, 4, v);
-    ifd.addEntry(0xC613, TIFF_BYTE, 4, v);
+    ifd.addEntry(0xC612, TIFF_BYTE, 4, static_tag_cache_.dng_version);
+    ifd.addEntry(0xC613, TIFF_BYTE, 4, static_tag_cache_.dng_version);
 
     /* black / white */
-    int32_t blackRat[8];
     for (int i = 0; i < 4; ++i) { blackRat[2 * i] = black[i]; blackRat[2 * i + 1] = 1; }
     ifd.addEntry(0xC61A, TIFF_RATIONAL, 4, blackRat);
     uint16_t white16 = static_cast<uint16_t>(dng_info.white);
     ifd.addEntry(0xC61D, TIFF_SHORT, 1, &white16);
 
     /* colour matrices */
-    ifd.addEntry(0xC621, TIFF_SRATIONAL, 9, matrixXY);   /* ColorMatrix1 */
-    ifd.addEntry(0xC622, TIFF_SRATIONAL, 9, matrixXY);   /* ColorMatrix2 */
-    uint16_t illum = 21;                                 /* D65 */
-    ifd.addEntry(0xC65A, TIFF_SHORT, 1, &illum);
-    ifd.addEntry(0xC65B, TIFF_SHORT, 1, &illum);
-    ifd.addEntry(0xC628, TIFF_RATIONAL, 3, neutral);     /* AsShotNeutral */
+    ifd.addEntry(0xC621, TIFF_SRATIONAL, 9, static_tag_cache_.matrixXY);   /* ColorMatrix1 */
+    ifd.addEntry(0xC622, TIFF_SRATIONAL, 9, static_tag_cache_.matrixXY);   /* ColorMatrix2 */
+    ifd.addEntry(0xC65A, TIFF_SHORT, 1, &static_tag_cache_.illumination);
+    ifd.addEntry(0xC65B, TIFF_SHORT, 1, &static_tag_cache_.illumination);
+    ifd.addEntry(0xC628, TIFF_RATIONAL, 3, static_tag_cache_.neutral);     /* AsShotNeutral */
 
     /* CFA pattern */
     ifd.addEntry(0xC619, TIFF_SHORT, 2, dng_info.black_level_repeat_dim);
@@ -866,7 +885,7 @@ size_t DngEncoder::dng_save([[maybe_unused]] int                /*thread_num*/,
     ifd.addEntry(0xC763, TIFF_BYTE, 8, tc);
 
     /* DateTimeOriginal */
-    char dateStr[20];
+    thread_local char dateStr[20];
     strftime(dateStr, sizeof(dateStr), "%Y:%m:%d %H:%M:%S", lt);
     ifd.addEntry(0x9003, TIFF_ASCII, 20, dateStr);
 
@@ -903,7 +922,6 @@ void DngEncoder::encodeThread(int num)
         }
 
         frames_ = encode_item.index;
-        console->trace("Thread[{}] encode frame: {}", num, encode_item.index);
 
         /* ────────────────────────────────────────────────────── */
         /*  RAM back-pressure + aligned allocation               */
@@ -1023,19 +1041,21 @@ void DngEncoder::diskThread(int num)
             decrementIfPositive(disk_queue_size_);
         }
 
-        std::ostringstream oss;
-        oss << options_->mediaDest << '/'
-            << options_->folder << '/'
-            << options_->folder << '_'
-            << std::setw(9) << std::setfill('0') << disk_item.index 
-            << ".dng";
-
-        std::string filename = oss.str();
+        thread_local std::string filename;
+        filename.clear();
+        filename.reserve(options_->mediaDest.size() + options_->folder.size() * 2 + 24);
+        filename.append(options_->mediaDest);
+        filename.push_back('/');
+        filename.append(options_->folder);
+        filename.push_back('/');
+        filename.append(options_->folder);
+        filename.push_back('_');
+        char frame_suffix[32];
+        std::snprintf(frame_suffix, sizeof(frame_suffix), "%09llu.dng", static_cast<unsigned long long>(disk_item.index));
+        filename.append(frame_suffix);
     
-        console->trace("Thread[{}]  Save frame to disk: {}", num, disk_item.index);
-
         if (options_ && options_->per_frame_logs && console->should_log(spdlog::level::debug))
-            console->debug("DNG written: {}", filename);
+            console->debug("DNG write start: {}", filename);
         
         auto start_time = std::chrono::high_resolution_clock::now();
         
@@ -1048,10 +1068,24 @@ void DngEncoder::diskThread(int num)
 
 
             // Always use actual used size returned by dng_save
-            ssize_t bytes_written = write(fd, disk_item.mem_buf, disk_item.size);
-            if (bytes_written < 0 || static_cast<size_t>(bytes_written) != disk_item.size) {
-                perror("Error writing to file");
+            size_t total_written = 0;
+            const uint8_t *src = static_cast<const uint8_t *>(disk_item.mem_buf);
+            while (total_written < disk_item.size)
+            {
+                ssize_t bytes_written = write(fd, src + total_written, disk_item.size - total_written);
+                if (bytes_written < 0)
+                {
+                    if (errno == EINTR)
+                        continue;
+                    perror("Error writing to file");
+                    break;
+                }
+                if (bytes_written == 0)
+                    break;
+                total_written += static_cast<size_t>(bytes_written);
             }
+            if (total_written != disk_item.size)
+                perror("Short write to file");
             close(fd);
         } else {
             perror("Failed to open file for writing");

--- a/cinepi/dng_encoder.hpp
+++ b/cinepi/dng_encoder.hpp
@@ -111,7 +111,7 @@ private:
     std::atomic<uint32_t> sampled_disk_latency_ms_{0};
     std::atomic<bool>     has_sampled_encode_latency_{false};
     std::atomic<bool>     has_sampled_disk_latency_{false};
-    uint32_t              latency_sample_interval_{10};
+    uint32_t              latency_sample_interval_{20};
     size_t                max_ram_buffers_;  /* hard cap calculated at setup  */
     std::mutex            ram_mtx_;
     std::condition_variable ram_cv_;
@@ -135,6 +135,19 @@ private:
     std::string model_tag_;
     std::string software_tag_;
     std::string ucm_tag_;
+    struct StaticTagCache
+    {
+        int32_t matrixXY[18]{};
+        int32_t neutral[6]{};
+        uint16_t planar{1};
+        uint16_t sample_format{1};
+        uint16_t illumination{21};
+        uint32_t sub_type{1};
+        uint8_t dng_version[4]{1, 4, 0, 0};
+        bool ready{false};
+    };
+    StaticTagCache static_tag_cache_;
+
 
         void encodeThread(int num);
         void diskThread(int num);

--- a/cinepi/raw_options.hpp
+++ b/cinepi/raw_options.hpp
@@ -55,14 +55,14 @@ struct RawOptions : public VideoOptions
     bool keep16;                           // set by --keep16 in CinePiOptions
 
     /* worker pool sizing + tuning */
-    uint32_t encode_workers { 2 };
-    uint32_t disk_workers   { 8 };
+    uint32_t encode_workers { 1 };
+    uint32_t disk_workers   { 1 };
     std::optional<std::vector<int>> encode_affinity;
     std::optional<std::vector<int>> disk_affinity;
     std::optional<int> encode_nice;
     std::optional<int> disk_nice;
 
     /* observability / logging tuning */
-    uint32_t latency_sample_interval { 10 };
+    uint32_t latency_sample_interval { 20 };
     bool per_frame_logs { false };
 };


### PR DESCRIPTION
### Motivation
- Reduce steady-state CPU usage and scheduling jitter in cinepi-raw while preserving 4K/25 reliability and existing recording semantics. 
- Target the hot paths: DNG encode/build and the disk write thread, while keeping cp_stats emission and Cinemate-compatible state/metadata unchanged. 
- Make low-risk runtime knobs the safe defaults for performance runs and provide a concise runtime summary for reproducible tests.

### Description
- Runtime defaults and startup logging: changed steady-state defaults to `encode_workers=1`, `disk_workers=1`, and `latency_sample_interval=20`, and added a one-time runtime summary log that prints `nopreview`, worker counts, `latency_sample_interval`, and `per_frame_logs` (files: `cinepi/raw_options.hpp`, `cinepi/cinepi_raw.cpp`).
- Preview control: `--nopreview` is now honored in the main frame loop to avoid preview-side work when disabled (file: `cinepi/cinepi_raw.cpp`).
- DNG encoder hot-path optimizations: introduced a `StaticTagCache` to precompute and reuse static DNG tag payloads (matrix/neutral arrays, sample format, planar, DNG version, illumination, subtype) and moved those computations to encoder setup so per-frame work only touches truly dynamic fields (time/date/timecode/fps); reduced per-frame allocations and removed unconditional trace logging from the encode loop (files: `cinepi/dng_encoder.hpp`, `cinepi/dng_encoder.cpp`).
- Disk-thread efficiency: replaced per-frame `ostringstream` filename building with a thread-local `std::string` + `snprintf` suffix, added a robust full-write loop that retries on `EINTR` and detects short writes, and kept `posix_fadvise` and naming/order semantics intact (file: `cinepi/dng_encoder.cpp`).
- Small helpers & ergonomics: added a local `cpuListToString` helper and made the encoder startup log print effective affinity/nice/perf options without changing behavior of existing affinity/nice CLI options (file: `cinepi/dng_encoder.cpp`).
- Observability & guardrails: cp_stats-related fields and sampling fields (encode/disk queue sizes, ram_buffers, sampled latencies, sensor timestamps, stats_seq) were preserved and left functional; Cinemate state model and file naming/recording semantics were not modified.

### Testing
- Ran `git diff --check` to verify there are no whitespace/diff-check errors; result: success.
- Attempted build setup with `meson setup build --buildtype=release`, but it could not run in this environment because `meson` is not installed (automated build was not available in container), so a full compile verification was not performed here.
- Attempted `python3 -m py_compile` on a C++ source file (not applicable) and failed; no C/C++ build was executed in this environment.

Automated test status summary: the repository-level quick check (`git diff --check`) succeeded; full build and runtime validation should be executed in the target build environment (with `meson` present) using the suggested A/B commands in the PR notes to measure CPU p95, encode/disk latency p95, and timestamp-gap events.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69addebf743483328ac903a0f3ff0f49)